### PR TITLE
DOCSTOOLS-197: support multiple anchors on the header

### DIFF
--- a/lib/plugins/anchors.js
+++ b/lib/plugins/anchors.js
@@ -3,11 +3,14 @@ const {bold} = require('chalk');
 
 const {headingInfo} = require('../utils');
 
-function createLinkTokens(state, id) {
+function createLinkTokens(state, id, setId = false) {
     const open = new state.Token('link_open', 'a', 1);
     const text = new state.Token('text', '', 0);
     const close = new state.Token('link_close', 'a', -1);
 
+    if (setId) {
+        open.attrSet('id', id);
+    }
     open.attrSet('href', '#' + id);
     open.attrSet('class', 'yfm-anchor');
     open.attrSet('aria-hidden', 'true');
@@ -16,8 +19,25 @@ function createLinkTokens(state, id) {
     return [open, text, close];
 }
 
+const CUSTOM_ID_REGEXP = /{ ?#(\S+) ?}/g;
+const getCustomIds = (content) => {
+    const ids = [];
+
+    content.replace(CUSTOM_ID_REGEXP, (match, customId) => {
+        ids.push(customId);
+    });
+
+    return ids.length ? ids : null;
+};
+const removeCustomIds = (token) => {
+    token.content = token.content.replace(CUSTOM_ID_REGEXP, '').trim();
+    token.children.forEach((child) => {
+        child.content = child.content.replace(CUSTOM_ID_REGEXP, '').trim();
+    });
+};
+
 function anchors(md, {extractTitleOption, path, log}) {
-    md.core.ruler.push('anchors', (state) => {
+    const plugin = (state) => {
         const ids = {};
         const tokens = state.tokens;
         let i = 0;
@@ -28,7 +48,10 @@ function anchors(md, {extractTitleOption, path, log}) {
 
             if (isHeading) {
                 const {title, level} = headingInfo(tokens, i);
+                const inlineToken = tokens[i + 1];
                 let id = token.attrGet('id');
+                let customIds;
+
                 if (!title) {
                     log.warn(`Header without title${path ? ` in ${bold(path)}` : ''}`);
                 }
@@ -39,7 +62,14 @@ function anchors(md, {extractTitleOption, path, log}) {
                 }
 
                 if (!id) {
-                    id = slugify(title || '', {lower: true});
+                    customIds = getCustomIds(inlineToken.content);
+                    if (customIds) {
+                        id = customIds[0];
+                        removeCustomIds(tokens[i + 1]);
+                    } else {
+                        id = slugify(title || '', {lower: true});
+                    }
+
                     token.attrSet('id', id);
                 }
 
@@ -50,15 +80,28 @@ function anchors(md, {extractTitleOption, path, log}) {
                     ids[id] = 1;
                 }
 
-                const inlineToken = tokens[i + 1];
-                const linkTokens = createLinkTokens(state, id);
+                const allAnchorIds = customIds ? customIds : [id];
 
-                inlineToken.children.unshift(...linkTokens);
+                allAnchorIds.forEach((customId) => {
+                    const setId = id !== customId;
+                    const linkTokens = createLinkTokens(state, customId, setId);
+
+                    inlineToken.children.unshift(...linkTokens);
+                });
+
+                i += 3;
+                continue;
             }
 
             i++;
         }
-    });
+    };
+
+    try {
+        md.core.ruler.before('links', 'anchors', plugin);
+    } catch (e) {
+        md.core.ruler.push('anchors', plugin);
+    }
 }
 
 module.exports = anchors;

--- a/lib/plugins/links.js
+++ b/lib/plugins/links.js
@@ -133,7 +133,15 @@ function links(md, opts) {
                 let j = 0;
 
                 while (j < childrenTokens.length) {
-                    if (childrenTokens[j].type === 'link_open') {
+                    const isLinkOpenToken = childrenTokens[j].type === 'link_open';
+                    const tokenClass = childrenTokens[j].attrGet('class');
+
+                    /*  Don't process anchor links */
+                    const isYfmAnchor = tokenClass
+                        ? tokenClass.includes('yfm-anchor')
+                        : false;
+
+                    if (isLinkOpenToken && !isYfmAnchor) {
                         processLink(state, childrenTokens, j, opts);
                     }
 
@@ -148,7 +156,7 @@ function links(md, opts) {
     };
 
     try {
-        md.core.ruler.before('includes', 'links', plugin);
+        md.core.ruler.after('includes', 'links', plugin);
     } catch (e) {
         md.core.ruler.push('links', plugin);
     }


### PR DESCRIPTION
Можно использовать так:
## Header {#custom1} { #custom2 }

Первый якорь устанавливается на тег заголовка, остальные якоря - это ссылки внутри заголовка с id

