### PR TITLE
DOCSTOOLS-20: add validation of links to a nonexistent page anchor

### DIFF
--- a/lib/plugins/anchors/index.js
+++ b/lib/plugins/anchors/index.js
@@ -3,6 +3,7 @@ const {bold} = require('chalk');
 const GithubSlugger = require('github-slugger');
 
 const {headingInfo} = require('../../utils');
+const {saveAnchor, setFileAsProcessedWithAnchors} = require('../../utilsFS');
 const {
     CUSTOM_ID_REGEXP,
     CUSTOM_ID_EXCEPTION,
@@ -104,7 +105,20 @@ function index(md, {extractTitle, path, log, supportGithubAnchors}) {
                     token.attrSet('id', id);
                 }
 
-                if (ids[id]) {
+                if (customIds) {
+                    customIds = customIds.map((customId) => {
+                        if (ids[customId]) {
+                            return customId + ids[customId]++;
+                        }
+
+                        ids[customId] = 1;
+
+                        return customId;
+                    });
+
+                    id = customIds[0];
+                    token.attrSet('id', id);
+                } else if (ids[id]) {
                     id = id + ids[id]++;
                     token.attrSet('id', id);
                 } else {
@@ -114,6 +128,8 @@ function index(md, {extractTitle, path, log, supportGithubAnchors}) {
                 const allAnchorIds = customIds ? customIds : [id];
 
                 allAnchorIds.forEach((customId) => {
+                    saveAnchor(path, customId);
+
                     const setId = id !== customId;
                     const linkTokens = createLinkTokens(state, customId, setId);
 
@@ -129,8 +145,20 @@ function index(md, {extractTitle, path, log, supportGithubAnchors}) {
                 continue;
             }
 
+            /* Save identifiers not only in headers */
+            if (CUSTOM_ID_REGEXP.test(token.content)) {
+                const customIds = getCustomIds(token.content);
+                if (customIds) {
+                    customIds.forEach((customId) => {
+                        saveAnchor(path, customId);
+                    });
+                }
+            }
+
             i++;
         }
+
+        setFileAsProcessedWithAnchors(path);
     };
 
     try {

--- a/lib/plugins/links/index.js
+++ b/lib/plugins/links/index.js
@@ -9,6 +9,7 @@ const {
 const {
     isFileExists,
     getFileTokens,
+    isExistAnchor,
 } = require('../../utilsFS');
 const {PAGE_LINK_REGEXP} = require('./constants');
 
@@ -111,6 +112,15 @@ function processLink(state, tokens, idx, opts) {
         isPageFile = true;
     } else {
         return;
+    }
+
+    if (hash && isPageFile && fileExists) {
+        const id = hash.slice(1);
+        const isIncludedFile = state.env.includes && state.env.includes.length;
+
+        if (!isIncludedFile && !isExistAnchor({file, id, root})) {
+            linkToken.attrSet('YFM004', true);
+        }
     }
 
     const isEmptyLink = nextToken.type === 'link_close';

--- a/lib/utilsFS.js
+++ b/lib/utilsFS.js
@@ -3,7 +3,10 @@ const {
     readFileSync,
     statSync,
 } = require('fs');
+const {bold} = require('chalk');
+const MarkdownIt = require('markdown-it');
 
+const log = require('./log');
 const liquid = require('./liquid');
 
 const filesCache = {};
@@ -90,10 +93,57 @@ function getSinglePageAnchorId({root, currentPath, pathname, hash}) {
     return `#${resultAnchor}`;
 }
 
+const anchorsInFiles = {};
+const saveAnchor = (path, id) => {
+    anchorsInFiles[path] = anchorsInFiles[path] || {};
+
+    if (anchorsInFiles[path]._processed) {
+        return;
+    }
+
+    if (!anchorsInFiles[path]._processed && anchorsInFiles[path][id]) {
+        log.error(`Anchor ${bold(id)} is duplicated in ${bold(path)}`);
+    }
+
+    anchorsInFiles[path][id] = true;
+};
+
+const setFileAsProcessedWithAnchors = (file) => {
+    anchorsInFiles[file] = anchorsInFiles[file] || {};
+    anchorsInFiles[file]._processed = true;
+
+    return Boolean(anchorsInFiles[file]);
+};
+
+const isExistAnchor = ({file, id, root}) => {
+    // There is anchor in cache
+    if (anchorsInFiles[file] && anchorsInFiles[file][id]) {
+        return true;
+    }
+
+    // File has been processed yet
+    if (anchorsInFiles[file] && anchorsInFiles[file]._processed && !anchorsInFiles[file][id]) {
+        return false;
+    }
+
+    const md = new MarkdownIt();
+    const includes = require('./plugins/includes'); // eslint-disable-line global-require
+    const anchors = require('./plugins/anchors'); // eslint-disable-line global-require
+    [includes, anchors].forEach((plugin) => md.use(plugin, {path: file, root}));
+
+    const content = readFileSync(file, 'utf8');
+    md.parse(content, {path: file, root});
+
+    return anchorsInFiles[file] && anchorsInFiles[file][id];
+};
+
 module.exports = {
     isFileExists,
     getFullIncludePath,
     resolveRelativePath,
     getFileTokens,
     getSinglePageAnchorId,
+    saveAnchor,
+    isExistAnchor,
+    setFileAsProcessedWithAnchors,
 };

--- a/lib/yfmlint/README.md
+++ b/lib/yfmlint/README.md
@@ -29,4 +29,12 @@ Aliases: unreachable-link
 
 This rule is triggered when there is no file referenced by the link.
 
+## YFM004 - Link is unreachable, hash does not exist
+
+Tags: links
+
+Aliases: unreachable-link-with-hash
+
+This rule is triggered when the file referenced by the link does not contain a hash.
+
 

--- a/lib/yfmlint/index.js
+++ b/lib/yfmlint/index.js
@@ -7,6 +7,7 @@ const {
     yfm001,
     yfm002,
     yfm003,
+    yfm004,
 } = require('./markdownlint-custom-rule');
 
 const {errorToString, getLogLevel} = require('./utils');
@@ -15,6 +16,7 @@ const defaultLintRules = [
     yfm001,
     yfm002,
     yfm003,
+    yfm004,
 ];
 
 function yfmlint(opts = {}) {

--- a/lib/yfmlint/markdownlint-custom-rule/index.js
+++ b/lib/yfmlint/markdownlint-custom-rule/index.js
@@ -1,9 +1,11 @@
 const yfm001 = require('./yfm001');
 const yfm002 = require('./yfm002');
 const yfm003 = require('./yfm003');
+const yfm004 = require('./yfm004');
 
 module.exports = {
     yfm001,
     yfm002,
     yfm003,
+    yfm004,
 };

--- a/lib/yfmlint/markdownlint-custom-rule/yfm004.js
+++ b/lib/yfmlint/markdownlint-custom-rule/yfm004.js
@@ -1,0 +1,30 @@
+module.exports = {
+    'names': ['YFM004', 'unreachable-link-with-hash'],
+    'description': 'Link is unreachable, hash does not exist',
+    'tags': ['links'],
+    'function': function YFM004(params, onError) {
+        const {config} = params;
+        if (!config) {
+            return;
+        }
+
+        params.tokens
+            .filter((token) => {
+                return token.type === 'inline';
+            })
+            .forEach((inline) => {
+                inline.children
+                    .filter((child) => {
+                        return child.type === 'link_open';
+                    })
+                    .forEach((link) => {
+                        if (link.attrGet('YFM004')) {
+                            onError({
+                                lineNumber: link.lineNumber,
+                                context: link.line,
+                            });
+                        }
+                    });
+            });
+    },
+};

--- a/lib/yfmlint/yfmlint.js
+++ b/lib/yfmlint/yfmlint.js
@@ -51,6 +51,7 @@ module.exports = {
         YFM001: 'warn', // Inline code length
         YFM002: 'warn', // No header found in the file for the link text
         YFM003: 'error', // Link is unreachable
+        YFM004: 'error', // Link is unreachable, hash does not exist
     },
 
     // Inline code length

--- a/test/markdownlint-custom-rules/yfm004.test.js
+++ b/test/markdownlint-custom-rules/yfm004.test.js
@@ -1,0 +1,33 @@
+const {readFileSync} = require('fs');
+const {resolve} = require('path');
+
+const {log} = require('../utils');
+const yfmlint = require('../../lib/yfmlint');
+const anchors = require('../../lib/plugins/anchors');
+const includes = require('../../lib/plugins/includes');
+const links = require('../../lib/plugins/links');
+
+describe('YFM004', () => {
+    beforeEach(() => {
+        log.clear();
+    });
+
+    test('Link is unreachable, hash does not exist', () => {
+
+        const root = resolve(__dirname, '../mocks/validateAnchors');
+        const path = `${root}/index.md`;
+        const input = readFileSync(path, 'utf8');
+
+        yfmlint({
+            input,
+            pluginOptions: {log, root, path},
+            plugins: [
+                includes,
+                links,
+                anchors,
+            ],
+        });
+
+        expect(log.get().error).toEqual([]);
+    });
+});

--- a/test/mocks/validateAnchors/_includes/include1.md
+++ b/test/mocks/validateAnchors/_includes/include1.md
@@ -1,0 +1,13 @@
+[test](#first)
+[test](#Second)
+[test](#Third)
+[test](#Fourth)
+
+### Third {#Third}
+
+{% include [test](./include2.md) %}
+
+[test](#first)
+[test](#Second)
+[test](#Third)
+[test](#Fourth)

--- a/test/mocks/validateAnchors/_includes/include2.md
+++ b/test/mocks/validateAnchors/_includes/include2.md
@@ -1,0 +1,13 @@
+[test](#first)
+[test](#Second)
+[test](#Third)
+[test](#Fourth)
+
+### Fourth {#Fourth}
+
+### Fourth {#Fourth}
+
+[test](#first)
+[test](#Second)
+[test](#Third)
+[test](#Fourth)

--- a/test/mocks/validateAnchors/index.md
+++ b/test/mocks/validateAnchors/index.md
@@ -1,0 +1,31 @@
+# Ссылка на якорь в другом файле
+
+
+## Дефолтный якорь
+
+[test](./page.md#first)
+
+## Кастомный якорь
+
+[test](./page.md#Second)
+
+## Якорь находится в включаемом файле
+
+[test](./page.md#Third)
+[test](./page.md#Fourth)
+
+## Несколько одинаковых дефолтных якорей
+
+[test](./page.md#default)
+[test](./page.md#default1)
+[test](./page.md#default2)
+
+## Несколько одинаковых кастомных якорей
+
+[test](./page.md#custom)
+[test](./page.md#custom1)
+[test](./page.md#custom2)
+
+## Ccылка на якорь вне заголовка 
+
+[test](./page.md#custom-body)

--- a/test/mocks/validateAnchors/page.md
+++ b/test/mocks/validateAnchors/page.md
@@ -1,0 +1,74 @@
+# Ссылка на якорь внутри файла
+
+
+## Дефолтный якорь
+
+Якорь находится в файле, ссылка указана до и после заголовка. 
+Заголовок приводится в нижний регистр.
+
+[test](#first)
+
+### First
+
+[test](#first)
+
+
+## Кастомный якорь
+
+Кастомный якорь находится в файле, ссылка указана до и после заголовка.
+Заголовок не приводится в нижний регистр.
+
+[test](#Second)
+
+### Second {#Second}
+
+[test](#Second)
+
+## Якорь находится в включаемом файле
+
+[test](#Third)
+[test](#Fourth)
+
+{% include [test](./_includes/include1.md) %}
+
+[test](#Third)
+[test](#Fourth)
+
+
+## Несколько одинаковых дефолтных якорей
+
+[test](#default)
+[test](#default1)
+[test](#default2)
+
+### default
+
+### default
+
+### default
+
+[test](#default)
+[test](#default1)
+[test](#default2)
+
+## Несколько одинаковых кастомных якорей
+
+[test](#custom)
+[test](#custom1)
+[test](#custom2)
+
+### custom {#custom}
+
+### custom {#custom}
+
+### custom {#custom}
+
+[test](#custom)
+[test](#custom1)
+[test](#custom2)
+
+
+## Кастомный якорь вне заголовка
+
+{#custom-body}
+


### PR DESCRIPTION
Сейчас есть ссылки на pathname документации сайта, ссылки на md файлы, но без расширения, ссылки на директории с index.md. Есть такие ссылки и с якорями, поэтому такие ссылки на якоря не валидируются, а пропускаются