### PR TITLE
fix(anchors): correctly process multiple anchors in transform

### DIFF
--- a/lib/plugins/anchors.js
+++ b/lib/plugins/anchors.js
@@ -24,7 +24,9 @@ const getCustomIds = (content) => {
     const ids = [];
 
     content.replace(CUSTOM_ID_REGEXP, (match, customId) => {
-        ids.push(customId);
+        if (customId) {
+            ids.push(customId);
+        }
     });
 
     return ids.length ? ids : null;
@@ -61,8 +63,8 @@ function anchors(md, {extractTitleOption, path, log}) {
                     continue;
                 }
 
+                customIds = getCustomIds(inlineToken.content);
                 if (!id) {
-                    customIds = getCustomIds(inlineToken.content);
                     if (customIds) {
                         id = customIds[0];
                         removeCustomIds(tokens[i + 1]);
@@ -71,6 +73,8 @@ function anchors(md, {extractTitleOption, path, log}) {
                     }
 
                     token.attrSet('id', id);
+                } else if (customIds) {
+                    removeCustomIds(tokens[i + 1]);
                 }
 
                 if (ids[id]) {


### PR DESCRIPTION
Former implementation of multiple anchors works fine in local site via
@doc-tools/docs, but has issues with @doc-tools/transform. This is
somehow related to the fact that `id` attribute is already set to one
of multiple anchors. Fix custom ids extraction accordingly.