### PR TITLE
DOCSTOOLS-444: remove special symbols

### DIFF
--- a/lib/plugins/anchors.js
+++ b/lib/plugins/anchors.js
@@ -81,7 +81,10 @@ function anchors(md, {extractTitleOption, path, log}) {
                         id = customIds[0];
                         removeCustomIds(tokens[i + 1]);
                     } else {
-                        id = slugify(title || '', {lower: true});
+                        id = slugify(title || '', {
+                            lower: true,
+                            remove: /[*+~.()'"!:@]/g,
+                        });
                     }
 
                     token.attrSet('id', id);


### PR DESCRIPTION
Если в заголовке на конце точка, то сформируется якорь с точкой на конце. Если дать ссылку c таким якорем, например, в телеграме, то телеграм подсветит часть ссылки без точки. Переход по такой ссылке произойдет в начало страницы, так как якорь без точки не найден

Предлагаю убрать все спец. символы