### PR TITLE
Docstools 166

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,16 @@
+const LOG_LEVELS = {
+    INFO: 'info',
+    WARN: 'warn',
+    ERROR: 'error',
+};
+
+const LOG_LEVELS_PRIORITIES = {
+    'info': 0,
+    'warn': 1,
+    'error': 2,
+};
+
+module.exports = {
+    LOG_LEVELS,
+    LOG_LEVELS_PRIORITIES,
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const MarkdownIt = require('markdown-it');
 const plugins = require('./plugins');
 const {
     inlineCodeMaxLen,
+    titleSyntax,
 } = require('./lintRules/preprocessRules');
 const log = require('./log');
 const makeHighlight = require('./highlight');
@@ -12,7 +13,7 @@ const getHeadings = require('./headings');
 const liquid = require('./liquid');
 
 const {notes, attrs, anchors, code, cut, deflist, imsize, meta, sup, tabs, video} = plugins;
-const preprocessLintRules = [inlineCodeMaxLen];
+const preprocessLintRules = [inlineCodeMaxLen, titleSyntax];
 
 function transform(originInput, opts = {}) {
     const {

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,15 @@ function transform(originInput, opts = {}) {
         log,
     };
 
-    const input = disableLiquid ? originInput : liquid(originInput, vars, path, {conditionsInCode});
+    const input = disableLiquid
+        ? originInput
+        : liquid(originInput, {
+            vars,
+            path,
+            lintOptions,
+            disableLint,
+            conditionsInCode,
+        });
 
     const highlight = makeHighlight(highlightLangs);
     const md = new MarkdownIt({html: allowHTML, linkify, highlight, breaks});

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,6 +15,7 @@ function transform(originInput, opts = {}) {
         vars = {}, path, extractTitle: extractTitleOption, needTitle,
         allowHTML = false, linkify = false, breaks = true, conditionsInCode = false, disableLiquid = false,
         plugins = [attrs, meta, deflist, cut, notes, anchors, tabs, code, imsize, sup, video], highlightLangs = {},
+        lintOptions = {}, disableLint = false,
         ...customOptions
     } = opts;
     const pluginOptions = {
@@ -23,6 +24,8 @@ function transform(originInput, opts = {}) {
         path,
         extractTitleOption,
         disableLiquid,
+        lintOptions,
+        disableLint,
         log,
     };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,9 @@ const {bold} = require('chalk');
 const MarkdownIt = require('markdown-it');
 
 const plugins = require('./plugins');
+const {
+    inlineCodeMaxLen,
+} = require('./lintRules/preprocessRules');
 const log = require('./log');
 const makeHighlight = require('./highlight');
 const extractTitle = require('./title');
@@ -9,6 +12,7 @@ const getHeadings = require('./headings');
 const liquid = require('./liquid');
 
 const {notes, attrs, anchors, code, cut, deflist, imsize, meta, sup, tabs, video} = plugins;
+const preprocessLintRules = [inlineCodeMaxLen];
 
 function transform(originInput, opts = {}) {
     const {
@@ -28,6 +32,21 @@ function transform(originInput, opts = {}) {
         disableLint,
         log,
     };
+
+    if (!disableLint) {
+        try {
+            preprocessLintRules.forEach((lintRule) => {
+                lintRule({
+                    input: originInput,
+                    lintOptions,
+                    commonOptions: {path, log},
+                });
+            });
+        } catch (e) {
+            console.log(e);
+            log.error(`Unexpected error while linting ${path ? `in ${bold(path)}` : ''}`);
+        }
+    }
 
     const input = disableLiquid
         ? originInput

--- a/lib/lintRules/liquidRules/index.js
+++ b/lib/lintRules/liquidRules/index.js
@@ -1,0 +1,7 @@
+const {withLintRuleWrapper} = require('../utils');
+
+const logVariableNotFound = withLintRuleWrapper(require('./logVariableNotFound'));
+
+module.exports = {
+    logVariableNotFound,
+};

--- a/lib/lintRules/liquidRules/logVariableNotFound.js
+++ b/lib/lintRules/liquidRules/logVariableNotFound.js
@@ -1,0 +1,20 @@
+const {bold} = require('chalk');
+const {LOG_LEVELS} = require('../../constants');
+
+const ruleName = 'liquid-variable-not-found';
+
+const defaultRuleOptions = {
+    level: LOG_LEVELS.WARN,
+};
+
+function logVariableNotFound({ruleOptions, commonOptions}) {
+    const {path, varPath, log} = commonOptions;
+    const {level} = ruleOptions;
+
+    log[level](`Variable ${bold(varPath)} not found${path ? ` in ${bold(path)}` : ''}. (${ruleName})`);
+}
+
+logVariableNotFound.ruleName = ruleName;
+logVariableNotFound.ruleOptions = defaultRuleOptions;
+
+module.exports = logVariableNotFound;

--- a/lib/lintRules/models.d.ts
+++ b/lib/lintRules/models.d.ts
@@ -1,0 +1,30 @@
+import {LOG_LEVELS} from '../constants';
+import {Logger} from '../log';
+
+export interface LintRuleOptions {
+    value?: any;
+    disabled?: boolean;
+    level?: LOG_LEVELS;
+}
+
+export interface LintRulesOptions {
+    [lintRuleName: string]: LintRuleOptions,
+}
+
+export interface LintCommonOptions {
+    log: Logger;
+    path: string;
+    disableLint?: boolean;
+}
+
+export interface LintRuleParams {
+    input?: string;
+    commonOptions: LintCommonOptions;
+    lintOptions?: LintRulesOptions;
+}
+
+export interface LintRuleFunction {
+    (params: LintRuleParams): void;
+    ruleName: string;
+    ruleOptions: LintRuleOptions;
+}

--- a/lib/lintRules/pluginsRules/index.js
+++ b/lib/lintRules/pluginsRules/index.js
@@ -1,0 +1,13 @@
+const {withLintRuleWrapper} = require('../utils');
+
+/* links */
+const logEmptyLinkHref = withLintRuleWrapper(require('./links/logEmptyLinkHref'));
+const logTitleRefLinkNotFound = withLintRuleWrapper(require('./links/logTitleRefLinkNotFound'));
+const logUnreachableLink = withLintRuleWrapper(require('./links/logUnreachableLink'));
+
+module.exports = {
+    /* links */
+    logEmptyLinkHref,
+    logTitleRefLinkNotFound,
+    logUnreachableLink,
+};

--- a/lib/lintRules/pluginsRules/links/logEmptyLinkHref.js
+++ b/lib/lintRules/pluginsRules/links/logEmptyLinkHref.js
@@ -1,0 +1,20 @@
+const {bold} = require('chalk');
+const {LOG_LEVELS} = require('../../../constants');
+
+const ruleName = 'links-empty-href';
+
+const defaultRuleOptions = {
+    level: LOG_LEVELS.WARN,
+};
+
+function logEmptyLinkHref({ruleOptions, commonOptions}) {
+    const {path, log} = commonOptions;
+    const {level} = ruleOptions;
+
+    log[level](`Empty link in ${bold(path)}`);
+}
+
+logEmptyLinkHref.ruleName = ruleName;
+logEmptyLinkHref.ruleOptions = defaultRuleOptions;
+
+module.exports = logEmptyLinkHref;

--- a/lib/lintRules/pluginsRules/links/logTitleRefLinkNotFound.js
+++ b/lib/lintRules/pluginsRules/links/logTitleRefLinkNotFound.js
@@ -1,0 +1,20 @@
+const {bold} = require('chalk');
+const {LOG_LEVELS} = require('../../../constants');
+
+const ruleName = 'title-ref-link-not-found';
+
+const defaultRuleOptions = {
+    level: LOG_LEVELS.WARN,
+};
+
+function logTitleRefLinkNotFound({ruleOptions, commonOptions}) {
+    const {path, href, log} = commonOptions;
+    const {level} = ruleOptions;
+
+    log[level](`Title not found: ${bold(href)} in ${bold(path)}. (${ruleName})`);
+}
+
+logTitleRefLinkNotFound.ruleName = ruleName;
+logTitleRefLinkNotFound.ruleOptions = defaultRuleOptions;
+
+module.exports = logTitleRefLinkNotFound;

--- a/lib/lintRules/pluginsRules/links/logUnreachableLink.js
+++ b/lib/lintRules/pluginsRules/links/logUnreachableLink.js
@@ -1,0 +1,20 @@
+const {bold} = require('chalk');
+const {LOG_LEVELS} = require('../../../constants');
+
+const ruleName = 'unreachable-link';
+
+const defaultRuleOptions = {
+    level: LOG_LEVELS.ERROR,
+};
+
+function logUnreachableLink({ruleOptions, commonOptions}) {
+    const {path, log, href} = commonOptions;
+    const {level} = ruleOptions;
+
+    log[level](`Link is unreachable: ${bold(href)} in ${bold(path)}. (${ruleName})`);
+}
+
+logUnreachableLink.ruleName = ruleName;
+logUnreachableLink.ruleOptions = defaultRuleOptions;
+
+module.exports = logUnreachableLink;

--- a/lib/lintRules/preprocessRules/index.d.ts
+++ b/lib/lintRules/preprocessRules/index.d.ts
@@ -1,0 +1,9 @@
+import {LintRuleFunction} from '../models';
+
+export interface LintRules {
+    inlineCodeMaxLen: LintRuleFunction;
+}
+
+declare let lintRules: LintRules;
+
+export default lintRules;

--- a/lib/lintRules/preprocessRules/index.d.ts
+++ b/lib/lintRules/preprocessRules/index.d.ts
@@ -2,6 +2,7 @@ import {LintRuleFunction} from '../models';
 
 export interface LintRules {
     inlineCodeMaxLen: LintRuleFunction;
+    titleSyntax: LintRuleFunction;
 }
 
 declare let lintRules: LintRules;

--- a/lib/lintRules/preprocessRules/index.js
+++ b/lib/lintRules/preprocessRules/index.js
@@ -1,0 +1,7 @@
+const {withLintRuleWrapper} = require('../utils');
+
+const inlineCodeMaxLen = withLintRuleWrapper(require('./inlineCodeMaxLen'));
+
+module.exports = {
+    inlineCodeMaxLen,
+};

--- a/lib/lintRules/preprocessRules/index.js
+++ b/lib/lintRules/preprocessRules/index.js
@@ -1,7 +1,9 @@
 const {withLintRuleWrapper} = require('../utils');
 
 const inlineCodeMaxLen = withLintRuleWrapper(require('./inlineCodeMaxLen'));
+const titleSyntax = withLintRuleWrapper(require('./titleSyntax'));
 
 module.exports = {
     inlineCodeMaxLen,
+    titleSyntax,
 };

--- a/lib/lintRules/preprocessRules/inlineCodeMaxLen.js
+++ b/lib/lintRules/preprocessRules/inlineCodeMaxLen.js
@@ -1,0 +1,36 @@
+const {bold} = require('chalk');
+
+const {LOG_LEVELS} = require('../../constants');
+const {getInlineCodes} = require('../../utils');
+
+const ruleName = 'inline-code-max-len';
+
+const defaultRuleOptions = {
+    level: LOG_LEVELS.WARN,
+    value: 100,
+};
+
+function inlineCodeMaxLen({input, ruleOptions: customRuleOptions, commonOptions}) {
+    const {path, log} = commonOptions;
+    const ruleOptions = {...defaultRuleOptions, ...customRuleOptions};
+    let {value} = ruleOptions;
+    const {level} = ruleOptions;
+
+    if (value < 0) {
+        value = defaultRuleOptions.value;
+    }
+
+    const inlineCodes = getInlineCodes(input);
+
+    for (const [line, lineNumber] of inlineCodes) {
+        if (line.length > value) {
+            log[level](`Length of inline code is longer than ${value}: line ${lineNumber} in ${bold(path)}.` +
+                ` Use the block code instead of the inline code. (${ruleName})`);
+        }
+    }
+}
+
+inlineCodeMaxLen.ruleName = ruleName;
+inlineCodeMaxLen.ruleOptions = defaultRuleOptions;
+
+module.exports = inlineCodeMaxLen;

--- a/lib/lintRules/preprocessRules/titleSyntax.js
+++ b/lib/lintRules/preprocessRules/titleSyntax.js
@@ -1,0 +1,43 @@
+const {bold} = require('chalk');
+
+const {LOG_LEVELS} = require('../../constants');
+
+const TITLE_RE = /^#{1,}[^\s#]{1}.*$/;
+const linkToSyntax = 'https://www.markdownguide.org/basic-syntax/#headings';
+
+const ruleName = 'title-syntax';
+
+const defaultRuleOptions = {
+    level: LOG_LEVELS.WARN,
+};
+
+function titleSyntax({input, ruleOptions: customRuleOptions, commonOptions}) {
+    const {path, log} = commonOptions;
+    const ruleOptions = {...defaultRuleOptions, ...customRuleOptions};
+    const {level} = ruleOptions;
+
+    const lines = input.split('\n');
+    let isBlockCodeStarted = false;
+
+    lines.forEach((line, index) => {
+        if (line.startsWith('```')) {
+            isBlockCodeStarted = !isBlockCodeStarted;
+
+            return;
+        } else if (isBlockCodeStarted) {
+            return;
+        }
+
+        const wrongTitle = line.match(TITLE_RE);
+
+        if (wrongTitle) {
+            log[level](`Incorrect syntax for title: line ${index + 1} in ${bold(path)}. ` +
+                `Check out syntax: ${linkToSyntax}. (${ruleName})`);
+        }
+    });
+}
+
+titleSyntax.ruleName = ruleName;
+titleSyntax.ruleOptions = defaultRuleOptions;
+
+module.exports = titleSyntax;

--- a/lib/lintRules/preprocessRules/titleSyntax.js
+++ b/lib/lintRules/preprocessRules/titleSyntax.js
@@ -20,11 +20,15 @@ function titleSyntax({input, ruleOptions: customRuleOptions, commonOptions}) {
     let isBlockCodeStarted = false;
 
     lines.forEach((line, index) => {
+        /* Check beginning or ending block code */
         if (line.startsWith('```')) {
             isBlockCodeStarted = !isBlockCodeStarted;
 
             return;
-        } else if (isBlockCodeStarted) {
+        }
+
+        /* Skip block code */
+        if (isBlockCodeStarted) {
             return;
         }
 

--- a/lib/lintRules/utils.d.ts
+++ b/lib/lintRules/utils.d.ts
@@ -1,0 +1,7 @@
+import {LintRuleParams, LogLevelsEnum} from './models';
+
+export function withLintRuleWrapper(params: LintRuleParams): void;
+
+export function isSupportedLevel(level: LogLevelsEnum): boolean;
+
+export function compareLogLevels(levelA: LogLevelsEnum, levelB: LogLevelsEnum): number;

--- a/lib/lintRules/utils.js
+++ b/lib/lintRules/utils.js
@@ -1,0 +1,106 @@
+const {LOG_LEVELS, LOG_LEVELS_PRIORITIES} = require('../constants');
+
+function isSupportedLevel(level) {
+    return Object.values(LOG_LEVELS).includes(level);
+}
+
+function compareLogLevels(levelA, levelB) {
+    return LOG_LEVELS_PRIORITIES[levelA] - LOG_LEVELS_PRIORITIES[levelB];
+}
+
+function withLintRuleProperties(wrapper, lintRule) {
+    wrapper.ruleName = lintRule.ruleName;
+    wrapper.ruleOptions = lintRule.ruleOptions;
+
+    return wrapper;
+}
+
+function withCheckDisabledRule(lintRule) {
+    function wrapper(params) {
+        const {ruleOptions} = params;
+
+        if (ruleOptions.disabled) {
+            return;
+        }
+
+        lintRule(params);
+    }
+
+    return withLintRuleProperties(wrapper, lintRule);
+}
+
+function getCountLogMessages(log, level) {
+    return log.get()[level].length;
+}
+
+function withValidationLevelOptions(lintRule) {
+    function wrapper(params) {
+        const {ruleOptions, commonOptions: {log, path}} = params;
+        const {level} = ruleOptions;
+
+        if (isSupportedLevel(level)) {
+            const messageCount = getCountLogMessages(log, level);
+
+            lintRule(params);
+
+            if (getCountLogMessages(log, level) > messageCount &&
+                compareLogLevels(lintRule.ruleOptions.level, level) > 0
+            ) {
+                log.warn(`The log level of lint rule "${lintRule.ruleName}" was decreased. ` +
+                    `This can lead to problems with content in ${path}`);
+            }
+        } else {
+            lintRule({...params, ruleOptions: {
+                ...ruleOptions,
+                level: lintRule.ruleOptions.level,
+            }});
+        }
+    }
+
+    return withLintRuleProperties(wrapper, lintRule);
+}
+
+function withDefaultOptions(lintRule) {
+    function wrapper(params) {
+        const {ruleOptions: customRuleOptions} = params;
+        const defaultRuleOptions = lintRule.ruleOptions || {};
+        const ruleOptions = {...defaultRuleOptions, ...customRuleOptions};
+
+        lintRule({...params, ruleOptions});
+    }
+
+    return withLintRuleProperties(wrapper, lintRule);
+}
+
+function withOwnOptions(lintRule) {
+    function wrapper(params) {
+        const {lintOptions = {}, commonOptions = {}} = params;
+
+        if (commonOptions.disableLint) {
+            return;
+        }
+
+        const ruleOptions = lintOptions[lintRule.ruleName] || {};
+
+        lintRule({...params, ruleOptions});
+    }
+
+    return withLintRuleProperties(wrapper, lintRule);
+}
+
+function withLintRuleWrapper(lintRule) {
+    return withOwnOptions(
+        withDefaultOptions(
+            withCheckDisabledRule(
+                withValidationLevelOptions(
+                    lintRule,
+                ))));
+}
+
+module.exports = {
+    withLintRuleWrapper,
+    isSupportedLevel,
+    compareLogLevels,
+};
+
+

--- a/lib/liquid/conditions.js
+++ b/lib/liquid/conditions.js
@@ -54,7 +54,7 @@ function inlineConditions({ifTag, vars, content, match, lastIndex}) {
     };
 }
 
-function conditions(originInput, vars, path) {
+function conditions(originInput, {vars, path} = {}) {
     const R_LIQUID = /({%-?([\s\S]*?)-?%})/g;
 
     let match;

--- a/lib/liquid/cycles.js
+++ b/lib/liquid/cycles.js
@@ -22,7 +22,7 @@ function inlineConditions({forTag, vars, content, match, path, lastIndex}) {
     const applyLiquid = require('./index');
     collection.forEach((item) => {
         const newVars = {...vars, [forTag.variableName]: item};
-        res += applyLiquid(forTemplate, newVars, path).trimRight();
+        res += applyLiquid(forTemplate, {vars: newVars, path}).trimRight();
     });
 
     const preparedLeftContent = getPreparedLeftContent({
@@ -50,7 +50,7 @@ function inlineConditions({forTag, vars, content, match, path, lastIndex}) {
     };
 }
 
-function cycles(originInput, vars, path) {
+function cycles(originInput, {vars, path} = {}) {
     const R_LIQUID = /({%-?([\s\S]*?)-?%})/g;
     const FOR_SYNTAX = new RegExp(`(\\w+)\\s+in\\s+(${variable.source})`);
 

--- a/lib/liquid/evaluation.js
+++ b/lib/liquid/evaluation.js
@@ -110,6 +110,8 @@ function evalExp(exp, scope) {
         }
 
         log.error(`Error: ${e}`);
+
+        return undefined;
     }
 }
 

--- a/lib/liquid/index.d.ts
+++ b/lib/liquid/index.d.ts
@@ -1,3 +1,5 @@
+import {LintRulesOptions} from '../lintRules/models';
+
 export default function liquid(
     originInput: string,
     options?: {
@@ -7,5 +9,7 @@ export default function liquid(
         conditionsInCode?: boolean;
         cycle?: boolean;
         substitutions?: boolean;
+        disableLint?: boolean;
+        lintOptions?: LintRulesOptions
     },
 ): string;

--- a/lib/liquid/index.d.ts
+++ b/lib/liquid/index.d.ts
@@ -1,11 +1,11 @@
 export default function liquid(
     originInput: string,
-    vars: Record<string, string>,
-    path: string,
-    settings?: {
+    options?: {
+        vars: Record<string, string>;
+        path: string;
         conditions?: boolean;
         conditionsInCode?: boolean;
         cycle?: boolean;
         substitutions?: boolean;
-    }
+    },
 ): string;

--- a/lib/liquid/index.js
+++ b/lib/liquid/index.js
@@ -5,7 +5,8 @@ const applySubstitutions = require('./substitutions');
 const codes = [];
 const regexp = /`{3}(((?!`{3})[^])+)`{3}/g;
 
-function saveCode(str, vars, path, substitutions) {
+function saveCode(str, options) {
+    const {substitutions} = options;
     let i = 0;
 
     return str.replace(
@@ -13,7 +14,7 @@ function saveCode(str, vars, path, substitutions) {
         (_, code) => {
             i++;
 
-            const codeWithVars = substitutions ? applySubstitutions(code, vars, path) : code;
+            const codeWithVars = substitutions ? applySubstitutions(code, options) : code;
 
             codes.push(codeWithVars);
 
@@ -29,20 +30,20 @@ function repairCode(str) {
     );
 }
 
-module.exports = (originInput, vars, path, settings = {}) => {
-    const {cycles = true, conditions = true, substitutions = true, conditionsInCode = false} = settings;
-    let input = conditionsInCode ? originInput : saveCode(originInput, vars, path, substitutions);
+module.exports = (originInput, options = {}) => {
+    const {cycles = true, conditions = true, substitutions = true, conditionsInCode = false} = options;
+    let input = conditionsInCode ? originInput : saveCode(originInput, options);
 
     if (cycles) {
-        input = applyCycles(input, vars, path);
+        input = applyCycles(input, options);
     }
 
     if (conditions) {
-        input = applyConditions(input, vars, path);
+        input = applyConditions(input, options);
     }
 
     if (substitutions) {
-        input = applySubstitutions(input, vars, path);
+        input = applySubstitutions(input, options);
     }
 
     input = conditionsInCode ? input : repairCode(input);

--- a/lib/liquid/substitutions.js
+++ b/lib/liquid/substitutions.js
@@ -1,11 +1,10 @@
-const {bold} = require('chalk');
-
 const getObject = require('../getObject');
 const {evalExp} = require('./evaluation');
 const log = require('../log');
 const {vars: varsRe, isVariable} = require('./lexical');
+const {logVariableNotFound} = require('../lintRules/liquidRules');
 
-const substitutions = (str, builtVars, path) => (
+const substitutions = (str, {vars: builtVars, path, lintOptions, disableLint} = {}) => (
     str.replace(
         varsRe,
         (match, _groupNotVar, flag, groupVar, groupVarValue) => {
@@ -29,7 +28,15 @@ const substitutions = (str, builtVars, path) => (
             if (value === undefined) {
                 value = match;
 
-                log.warn(`Variable ${bold(trimVarPath)} not found${path ? ` in ${bold(path)}` : ''}`);
+                logVariableNotFound({
+                    lintOptions,
+                    commonOptions: {
+                        path,
+                        varPath: trimVarPath,
+                        disableLint,
+                        log,
+                    },
+                });
             }
 
             return value;

--- a/lib/log.d.ts
+++ b/lib/log.d.ts
@@ -4,11 +4,20 @@ export interface Logs {
     error: string[];
 }
 
+enum LogLevels {
+    INFO = 'info',
+    WARN = 'warn',
+    ERROR = 'error',
+}
+
 export interface Logger {
     info: Function;
     warn: Function;
     error: Function;
     get: () => Logs;
+    clear: () => void;
+    isEmpty: () => boolean;
+    LOG_LEVELS: LogLevels;
 }
 
 declare let log: Logger;

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,9 +1,10 @@
 const {green, yellow, red} = require('chalk');
+const {LOG_LEVELS} = require('./constants');
 
 const problems = {
-    info: [],
-    warn: [],
-    error: [],
+    [LOG_LEVELS.INFO]: [],
+    [LOG_LEVELS.WARN]: [],
+    [LOG_LEVELS.ERROR]: [],
 };
 
 function createLogger(type) {
@@ -21,8 +22,21 @@ function createLogger(type) {
 }
 
 module.exports = {
-    info: createLogger('info'),
-    warn: createLogger('warn'),
-    error: createLogger('error'),
+    [LOG_LEVELS.INFO]: createLogger(LOG_LEVELS.INFO),
+    [LOG_LEVELS.WARN]: createLogger(LOG_LEVELS.WARN),
+    [LOG_LEVELS.ERROR]: createLogger(LOG_LEVELS.ERROR),
+    LOG_LEVELS,
     get: () => problems,
+    clear: () => {
+        problems[LOG_LEVELS.INFO] = [];
+        problems[LOG_LEVELS.WARN] = [];
+        problems[LOG_LEVELS.ERROR] = [];
+    },
+    isEmpty: () => {
+        return !(
+            problems[LOG_LEVELS.INFO].length ||
+            problems[LOG_LEVELS.WARN].length ||
+            problems[LOG_LEVELS.ERROR].length
+        );
+    },
 };

--- a/lib/plugins/links.js
+++ b/lib/plugins/links.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const url = require('url');
-const {bold} = require('chalk');
 const MarkdownIt = require('markdown-it');
 const {
     isLocalUrl,
@@ -10,6 +9,11 @@ const {
     headingInfo,
     getSinglePageAnchorId,
 } = require('../utils');
+const {
+    logEmptyLinkHref,
+    logTitleRefLinkNotFound,
+    logUnreachableLink,
+} = require('../lintRules/pluginsRules');
 
 const PAGE_LINK_REGEXP = /\.(md|ya?ml)$/i;
 
@@ -41,7 +45,9 @@ function getTitleFromTokens(tokens) {
     return title;
 }
 
-const addTitle = ({hash, file, state, opts, isEmptyLink, tokens, idx, nextToken, href, currentPath, log}) => {
+const addTitle = ({hash, file, state, opts, isEmptyLink, tokens, idx, nextToken, href, currentPath}) => {
+    const {log, lintOptions, disableLint} = opts;
+
     const id = hash && hash.slice(1);
     const fileTokens = getFileTokens(file, state, opts);
     const sourceTokens = id ? findBlockTokens(fileTokens, id) : fileTokens;
@@ -59,20 +65,26 @@ const addTitle = ({hash, file, state, opts, isEmptyLink, tokens, idx, nextToken,
 
         textToken.content = title;
     } else {
-        log.warn(`Title not found: ${bold(href)} in ${bold(currentPath)}`);
+        logTitleRefLinkNotFound({
+            lintOptions,
+            commonOptions: {log, path: currentPath, href, disableLint},
+        });
     }
 };
 
 // eslint-disable-next-line complexity
 function processLink(state, tokens, idx, opts) {
-    const {path: startPath, root, transformLink, notFoundCb, needSkipLinkFn, log} = opts;
+    const {path: startPath, root, transformLink, notFoundCb, needSkipLinkFn, log, lintOptions, disableLint} = opts;
     const currentPath = state.env.path || startPath;
     const linkToken = tokens[idx];
     const nextToken = tokens[idx + 1];
     let href = linkToken.attrGet('href');
 
     if (!href) {
-        log.error(`Empty link in ${bold(startPath)}`);
+        logEmptyLinkHref({
+            lintOptions,
+            commonOptions: {log, path: startPath, disableLint},
+        });
         return;
     }
 
@@ -103,7 +115,10 @@ function processLink(state, tokens, idx, opts) {
             }
 
             if (needShowError) {
-                log.error(`Link is unreachable: ${bold(href)} in ${bold(currentPath)}`);
+                logUnreachableLink({
+                    lintOptions,
+                    commonOptions: {log, path: currentPath, href, disableLint},
+                });
             }
         }
     } else if (hash) {
@@ -117,7 +132,7 @@ function processLink(state, tokens, idx, opts) {
     const isEmptyLink = nextToken.type === 'link_close';
     const isTitleRefLink = nextToken.type === 'text' && nextToken.content === '{#T}';
     if ((isEmptyLink || isTitleRefLink) && fileExists && isPageFile) {
-        addTitle({hash, file, state, opts, isEmptyLink, tokens, idx, nextToken, href, currentPath, log});
+        addTitle({hash, file, state, opts, isEmptyLink, tokens, idx, nextToken, href, currentPath});
     }
 
     let newPathname;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -28,7 +28,7 @@ function resolveRelativePath(fromPath, relativePath) {
 }
 
 function getFileTokens(path, state, options) {
-    const {getVarsPerFile, vars, disableLiquid} = options;
+    const {getVarsPerFile, vars, disableLiquid, lintOptions, disableLint} = options;
     let content;
 
     if (filesCache[path]) {
@@ -36,7 +36,7 @@ function getFileTokens(path, state, options) {
     } else {
         content = readFileSync(path, 'utf8');
         const builtVars = getVarsPerFile ? getVarsPerFile(path) : vars;
-        content = disableLiquid ? content : liquid(content, builtVars, path);
+        content = disableLiquid ? content : liquid(content, builtVars, path, {}, {lintOptions, disableLint});
         filesCache[path] = content;
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,7 +36,7 @@ function getFileTokens(path, state, options) {
     } else {
         content = readFileSync(path, 'utf8');
         const builtVars = getVarsPerFile ? getVarsPerFile(path) : vars;
-        content = disableLiquid ? content : liquid(content, builtVars, path, {}, {lintOptions, disableLint});
+        content = disableLiquid ? content : liquid(content, {vars: builtVars, path, lintOptions, disableLint});
         filesCache[path] = content;
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -150,6 +150,83 @@ function transformLinkToOriginalArticle({root, currentPath}) {
         .replace(/\.(md|ya?ml|html)$/i, '');
 }
 
+function getInlineCodes(input) {
+    const lines = input.split('\n');
+
+    let wasInlineCodeClosed = true;
+    let firstLineIndex = -1;
+    let isMiddleLine = false;
+    let foundClosedLine = false;
+    let isBlockCodeStarted = false;
+    return lines.reduce((res, line, index) => {
+        if (line.startsWith('```')) {
+            isBlockCodeStarted = !isBlockCodeStarted;
+
+            return res;
+        } else if (isBlockCodeStarted) {
+            return res;
+        }
+
+        if (!isBlockCodeStarted && line.startsWith('```')) {
+            isBlockCodeStarted = true;
+            return res;
+        } else if (isBlockCodeStarted) {
+            isBlockCodeStarted = false;
+            return res;
+        }
+
+        let curQuoteIndex = 0;
+        let prevQuoteIndex = -1;
+
+        while (curQuoteIndex !== -1) {
+            const partLine = line.slice(prevQuoteIndex + 1);
+            const foundIndexInPartLine = partLine.indexOf('`');
+
+            /* Line without quotes of inline code */
+            if (foundIndexInPartLine === -1) {
+                isMiddleLine = foundClosedLine ? false : firstLineIndex !== -1;
+                break;
+            }
+
+            curQuoteIndex = foundIndexInPartLine + prevQuoteIndex + 1;
+
+            if (
+                /* Skip block code */
+                (curQuoteIndex - 1 > -1 && line[curQuoteIndex - 1] === '`') ||
+                (curQuoteIndex + 1 < line.length && line[curQuoteIndex + 1] === '`')
+            ) {
+                break;
+            } else if (firstLineIndex === -1) {
+                /* Found quote of inline code */
+                wasInlineCodeClosed = !wasInlineCodeClosed;
+            } else {
+                foundClosedLine = true;
+            }
+
+            if (wasInlineCodeClosed) {
+                const inlineCode = line.slice(prevQuoteIndex + 1, curQuoteIndex);
+                res.push([inlineCode, index + 1]);
+            }
+
+            prevQuoteIndex = curQuoteIndex;
+        }
+
+        if (!wasInlineCodeClosed && !isMiddleLine) {
+            if (firstLineIndex === -1) {
+                firstLineIndex = index;
+            } else {
+                const inlineCode = lines.slice(firstLineIndex + 1, index).join(' ');
+                res.push([inlineCode, firstLineIndex + 1]);
+                firstLineIndex = -1;
+                foundClosedLine = false;
+                wasInlineCodeClosed = true;
+            }
+        }
+
+        return res;
+    }, []);
+}
+
 module.exports = {
     isLocalUrl,
     isFileExists,
@@ -161,4 +238,5 @@ module.exports = {
     isExternalHref,
     getSinglePageAnchorId,
     transformLinkToOriginalArticle,
+    getInlineCodes,
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -153,25 +153,27 @@ function transformLinkToOriginalArticle({root, currentPath}) {
 function getInlineCodes(input) {
     const lines = input.split('\n');
 
-    let wasInlineCodeClosed = true;
-    let firstLineIndex = -1;
-    let isMiddleLine = false;
-    let foundClosedLine = false;
+    let openedQuoteLineIndex = -1;
+    let openedQuoteIndex = -1;
+    let isInlineOpened = false;
     let isBlockCodeStarted = false;
     return lines.reduce((res, line, index) => {
+        /* Check beginning or ending block code */
         if (line.startsWith('```')) {
             isBlockCodeStarted = !isBlockCodeStarted;
 
             return res;
-        } else if (isBlockCodeStarted) {
+        }
+
+        /* Skip block code */
+        if (isBlockCodeStarted) {
             return res;
         }
 
-        if (!isBlockCodeStarted && line.startsWith('```')) {
-            isBlockCodeStarted = true;
-            return res;
-        } else if (isBlockCodeStarted) {
-            isBlockCodeStarted = false;
+        /* Skip empty lines */
+        if (!line) {
+            openedQuoteLineIndex = -1;
+            isInlineOpened = false;
             return res;
         }
 
@@ -179,48 +181,46 @@ function getInlineCodes(input) {
         let prevQuoteIndex = -1;
 
         while (curQuoteIndex !== -1) {
+            /* Searching quote in part of line */
             const partLine = line.slice(prevQuoteIndex + 1);
             const foundIndexInPartLine = partLine.indexOf('`');
 
-            /* Line without quotes of inline code */
+            /* Not found quotes in rest part of the line */
             if (foundIndexInPartLine === -1) {
-                isMiddleLine = foundClosedLine ? false : firstLineIndex !== -1;
                 break;
             }
 
+            /* Found index for a current quote in original line */
             curQuoteIndex = foundIndexInPartLine + prevQuoteIndex + 1;
 
-            if (
-                /* Skip block code */
-                (curQuoteIndex - 1 > -1 && line[curQuoteIndex - 1] === '`') ||
-                (curQuoteIndex + 1 < line.length && line[curQuoteIndex + 1] === '`')
-            ) {
-                break;
-            } else if (firstLineIndex === -1) {
-                /* Found quote of inline code */
-                wasInlineCodeClosed = !wasInlineCodeClosed;
-            } else {
-                foundClosedLine = true;
-            }
+            /* Found quote of inline code */
+            if (isInlineOpened) {
+                let inlineCode = '';
+                if (openedQuoteLineIndex === index) { // single-line inline code
+                    inlineCode = line.slice(prevQuoteIndex + 1, curQuoteIndex);
+                } else { // multi-line inline code
+                    const inlineLines = [
+                        lines[openedQuoteLineIndex].slice(openedQuoteIndex + 1),
+                        ...lines.slice(openedQuoteLineIndex + 1, index),
+                        lines[index].slice(0, curQuoteIndex),
+                    ].filter(Boolean);
+                    inlineCode = inlineLines.join(' ');
+                }
 
-            if (wasInlineCodeClosed) {
-                const inlineCode = line.slice(prevQuoteIndex + 1, curQuoteIndex);
-                res.push([inlineCode, index + 1]);
+                if (inlineCode) {
+                    res.push([inlineCode, openedQuoteLineIndex + 1]);
+                }
+
+                isInlineOpened = false;
+                openedQuoteLineIndex = -1;
+
+            } else {
+                isInlineOpened = true;
+                openedQuoteLineIndex = index;
+                openedQuoteIndex = curQuoteIndex;
             }
 
             prevQuoteIndex = curQuoteIndex;
-        }
-
-        if (!wasInlineCodeClosed && !isMiddleLine) {
-            if (firstLineIndex === -1) {
-                firstLineIndex = index;
-            } else {
-                const inlineCode = lines.slice(firstLineIndex + 1, index).join(' ');
-                res.push([inlineCode, firstLineIndex + 1]);
-                firstLineIndex = -1;
-                foundClosedLine = false;
-                wasInlineCodeClosed = true;
-            }
         }
 
         return res;

--- a/test/links.test.js
+++ b/test/links.test.js
@@ -4,6 +4,8 @@ const links = require('../lib/plugins/links');
 const {callPlugin, tokenize} = require('./utils');
 const {title, customTitle} = require('./data/links');
 
+const {log} = require('./utils');
+
 const callLinksPlugin = callPlugin.bind(null, links);
 
 describe('Links', () => {
@@ -39,5 +41,49 @@ describe('Links', () => {
         });
 
         expect(result).toEqual(title);
+    });
+
+    describe('Linting', () => {
+        beforeEach(() => {
+            log.clear();
+        });
+
+        test('Empty link warn', () => {
+            const mocksPath = require.resolve('./utils.js');
+
+            callLinksPlugin(tokenize(['[Text]()']), {
+                path: mocksPath,
+                root: dirname(mocksPath),
+                log,
+            });
+
+            expect(log.get().warn[0].includes('Empty link in')).toEqual(true);
+        });
+
+        test('Empty link error', () => {
+            const mocksPath = require.resolve('./utils.js');
+
+            callLinksPlugin(tokenize(['[Text]()']), {
+                path: mocksPath,
+                root: dirname(mocksPath),
+                log,
+                lintOptions: {'links-empty-href': {level: 'error'}},
+            });
+
+            expect(log.get().error[0].includes('Empty link in')).toEqual(true);
+        });
+
+        test('Empty link disabled', () => {
+            const mocksPath = require.resolve('./utils.js');
+
+            callLinksPlugin(tokenize(['[Text]()']), {
+                path: mocksPath,
+                root: dirname(mocksPath),
+                log,
+                lintOptions: {'links-empty-href': {level: 'error', disabled: true}},
+            });
+
+            expect(log.get().error.length).toEqual(0);
+        });
     });
 });

--- a/test/lintRules/inlineCodeMaxLen.test.js
+++ b/test/lintRules/inlineCodeMaxLen.test.js
@@ -25,6 +25,11 @@ prefix \`another inline quotes inside block code\` postfix
 \`\`\`sql
 block code
 \`\`\`
+
+\`, ?, !
+
+Some text for testing not escaped and not closed quote
+\`
 `.trim();
 
 const inlineCodes = [

--- a/test/lintRules/inlineCodeMaxLen.test.js
+++ b/test/lintRules/inlineCodeMaxLen.test.js
@@ -1,0 +1,76 @@
+const {inlineCodeMaxLen} = require('../../lib/lintRules/preprocessRules');
+const {getInlineCodes} = require('../../lib/utils');
+const {LOG_LEVELS} = require('../../lib/constants');
+const {log} = require('../utils');
+
+const testInput = `
+\`single-line inline code\` \`another single-line inline code\`
+
+\`
+multi-line inline code
+\`
+
+\`
+another multi-line
+inline code
+\`
+
+\`|\`
+
+\`\`\`
+prefix \`inline quotes inside block code\` postfix
+prefix \`another inline quotes inside block code\` postfix
+\`\`\`
+
+\`\`\`sql
+block code
+\`\`\`
+`.trim();
+
+const inlineCodes = [
+    ['single-line inline code', 1],
+    ['another single-line inline code', 1],
+    ['multi-line inline code', 3],
+    ['another multi-line inline code', 7],
+    ['|', 12],
+];
+
+describe('inline-code-max-len rule', () => {
+    beforeEach(() => {
+        log.clear();
+    });
+
+    it('Test function for getting inline codes', () => {
+        expect(getInlineCodes(testInput)).toEqual(inlineCodes);
+    });
+
+    it('All inline codes are shorter than value', () => {
+        inlineCodeMaxLen({
+            input: testInput,
+            lintOptions: {[inlineCodeMaxLen.ruleName]: {value: 80}},
+            commonOptions: {log, path: ''},
+        });
+
+        expect(log.isEmpty()).toEqual(true);
+    });
+
+    it('All inline codes are longer than value', () => {
+        inlineCodeMaxLen({
+            input: testInput,
+            lintOptions: {[inlineCodeMaxLen.ruleName]: {value: 5}},
+            commonOptions: {log, path: ''},
+        });
+
+        expect(log.get().warn.length).toEqual(4);
+    });
+
+    it('Change log level', () => {
+        inlineCodeMaxLen({
+            input: testInput,
+            lintOptions: {[inlineCodeMaxLen.ruleName]: {value: 5, level: LOG_LEVELS.ERROR}},
+            commonOptions: {log, path: ''},
+        });
+
+        expect(log.get().error.length).toEqual(4);
+    });
+});

--- a/test/lintRules/titleSyntax.test.js
+++ b/test/lintRules/titleSyntax.test.js
@@ -1,0 +1,48 @@
+const {titleSyntax} = require('../../lib/lintRules/preprocessRules');
+const {log} = require('../utils');
+const {LOG_LEVELS} = require('../../lib/constants');
+
+const testInput = `
+# Correct title h1
+
+## Correct title h2
+
+#Invalid title h1
+
+##Invalid title h2
+`.trim();
+
+describe('title-syntax rule', () => {
+    beforeEach(() => {
+        log.clear();
+    });
+
+    it('Two errors', () => {
+        titleSyntax({
+            input: testInput,
+            lintOptions: {[titleSyntax.ruleName]: {level: LOG_LEVELS.ERROR}},
+            commonOptions: {log, path: ''},
+        });
+
+        expect(log.get().error.length).toEqual(2);
+    });
+
+    it('Two warns', () => {
+        titleSyntax({
+            input: testInput,
+            commonOptions: {log, path: ''},
+        });
+
+        expect(log.get().warn.length).toEqual(2);
+    });
+
+    it('Disabled', () => {
+        titleSyntax({
+            input: testInput,
+            lintOptions: {[titleSyntax.ruleName]: {level: LOG_LEVELS.WARN, disabled: true}},
+            commonOptions: {log, path: ''},
+        });
+
+        expect(log.get().warn.length).toEqual(0);
+    });
+});

--- a/test/liquid/conditions.test.js
+++ b/test/liquid/conditions.test.js
@@ -6,7 +6,7 @@ describe('Conditions', () => {
             expect(
                 conditions(
                     'Prefix {% if user %} Inline if {% endif %} Postfix',
-                    {user: {name: 'Alice'}},
+                    {vars: {user: {name: 'Alice'}}}
                 ),
             ).toEqual('Prefix Inline if Postfix');
         });
@@ -15,7 +15,7 @@ describe('Conditions', () => {
             expect(
                 conditions(
                     'Prefix {% if user %} Inline if {% else %} else {% endif %} Postfix',
-                    {user: {name: 'Alice'}},
+                    {vars: {user: {name: 'Alice'}}},
                 ),
             ).toEqual('Prefix Inline if Postfix');
         });
@@ -24,7 +24,7 @@ describe('Conditions', () => {
             expect(
                 conditions(
                     'Prefix {% if yandex %} Inline if {% else %} else {% endif %} Postfix',
-                    {user: {name: 'Alice'}},
+                    {vars: {user: {name: 'Alice'}}},
                 ),
             ).toEqual('Prefix else Postfix');
         });
@@ -33,7 +33,7 @@ describe('Conditions', () => {
             expect(
                 conditions(
                     'Prefix {% if yandex %} Inline if {% elsif user %} else {% endif %} Postfix',
-                    {user: {name: 'Alice'}},
+                    {vars: {user: {name: 'Alice'}}},
                 ),
             ).toEqual(
                 'Prefix else Postfix');
@@ -46,7 +46,7 @@ describe('Conditions', () => {
                     '    How are you?\n' +
                     '{% endif %}\n' +
                     'Postfix',
-                    {test: true},
+                    {vars: {test: true}},
                 ),
             ).toEqual(
                 'Prefix\n' +
@@ -63,7 +63,7 @@ describe('Conditions', () => {
                     '    How are you?\n' +
                     '    {% endif %}\n' +
                     'Postfix',
-                    {test: true},
+                    {vars: {test: true}},
                 ),
             ).toEqual(
                 'Prefix\n' +
@@ -80,7 +80,7 @@ describe('Conditions', () => {
                     '         How are you?\n' +
                     '     {% endif %}\n' +
                     'Postfix',
-                    {test: false},
+                    {vars: {test: false}},
                 ),
             ).toEqual(
                 'Prefix\n' +
@@ -97,7 +97,7 @@ describe('Conditions', () => {
                     '{% if test %}\n' +
                     '    How are you?\n' +
                     '{% endif %}',
-                    {test: true},
+                    {vars: {test: true}},
                 ),
             ).toEqual(
                 '    How are you?\n' +
@@ -128,7 +128,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user %} Inline if {% endif %} Postfix',
-                        {user: {name: 'Alice'}},
+                        {vars: {user: {name: 'Alice'}}},
                     ),
                 ).toEqual('Prefix Inline if Postfix');
             });
@@ -137,7 +137,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.name == \'Alice\' %} Inline if {% endif %} Postfix',
-                        {user: {name: 'Alice'}},
+                        {vars: {user: {name: 'Alice'}}},
                     ),
                 ).toEqual('Prefix Inline if Postfix');
             });
@@ -146,7 +146,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.name != \'Bob\' %} Inline if {% endif %} Postfix',
-                        {user: {name: 'Alice'}},
+                        {vars: {user: {name: 'Alice'}}},
                     ),
                 ).toEqual('Prefix Inline if Postfix');
             });
@@ -155,7 +155,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.age >= 18 %} Inline if {% endif %} Postfix',
-                        {user: {age: 18}},
+                        {vars: {user: {age: 18}}},
                     ),
                 ).toEqual('Prefix Inline if Postfix');
             });
@@ -164,7 +164,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.age > 18 %} Inline if {% endif %} Postfix',
-                        {user: {age: 21}},
+                        {vars: {user: {age: 21}}},
                     ),
                 ).toEqual('Prefix Inline if Postfix');
             });
@@ -173,7 +173,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.age <= 18 %} Inline if {% endif %} Postfix',
-                        {user: {age: 18}},
+                        {vars: {user: {age: 18}}},
                     ),
                 ).toEqual('Prefix Inline if Postfix');
             });
@@ -182,7 +182,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.age < 18 %} Inline if {% endif %} Postfix',
-                        {user: {age: 1}},
+                        {vars: {user: {age: 1}}},
                     ),
                 ).toEqual('Prefix Inline if Postfix');
             });
@@ -191,7 +191,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user and user.age >= 18 %} Inline if {% endif %} Postfix',
-                        {user: {age: 18}},
+                        {vars: {user: {age: 18}}},
                     ),
                 ).toEqual('Prefix Inline if Postfix');
             });
@@ -200,7 +200,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.age < 18 or user.age >= 21 %} Inline if {% endif %} Postfix',
-                        {user: {age: 21}},
+                        {vars: {user: {age: 21}}},
                     ),
                 ).toEqual('Prefix Inline if Postfix');
             });
@@ -211,7 +211,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if yandex %} Inline if {% else %} else {% endif %} Postfix',
-                        {user: {name: 'Alice'}},
+                        {vars: {user: {name: 'Alice'}}},
                     ),
                 ).toEqual('Prefix else Postfix');
             });
@@ -220,7 +220,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.name == \'Alice\' %} Inline if {% else %} else {% endif %} Postfix',
-                        {user: {name: 'Bob'}},
+                        {vars: {user: {name: 'Bob'}}},
                     ),
                 ).toEqual('Prefix else Postfix');
             });
@@ -229,7 +229,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.name != \'Bob\' %} Inline if {% else %} else {% endif %} Postfix',
-                        {user: {name: 'Bob'}},
+                        {vars: {user: {name: 'Bob'}}},
                     ),
                 ).toEqual('Prefix else Postfix');
             });
@@ -238,7 +238,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.age >= 18 %} Inline if {% else %} else {% endif %} Postfix',
-                        {user: {age: 1}},
+                        {vars: {user: {age: 1}}},
                     ),
                 ).toEqual('Prefix else Postfix');
             });
@@ -247,7 +247,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.age > 18 %} Inline if {% else %} else {% endif %} Postfix',
-                        {user: {age: 1}},
+                        {vars: {user: {age: 1}}},
                     ),
                 ).toEqual('Prefix else Postfix');
             });
@@ -256,7 +256,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.age <= 18 %} Inline if {% else %} else {% endif %} Postfix',
-                        {user: {age: 21}},
+                        {vars: {user: {age: 21}}},
                     ),
                 ).toEqual('Prefix else Postfix');
             });
@@ -265,7 +265,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user.age < 18 %} Inline if {% else %} else {% endif %} Postfix',
-                        {user: {age: 21}},
+                        {vars: {user: {age: 21}}},
                     ),
                 ).toEqual('Prefix else Postfix');
             });
@@ -274,7 +274,7 @@ describe('Conditions', () => {
                 expect(
                     conditions(
                         'Prefix {% if user and user.age >= 18 %} Inline if {% else %} else {% endif %} Postfix',
-                        {user: {age: 1}},
+                        {vars: {user: {age: 1}}},
                     ),
                 ).toEqual('Prefix else Postfix');
             });
@@ -284,7 +284,7 @@ describe('Conditions', () => {
                     conditions(
                         'Prefix {% if user.age < 18 or user.age >= 21 %} Inline if {% else %} else ' +
                         '{% endif %} Postfix',
-                        {user: {age: 20}},
+                        {vars: {user: {age: 20}}},
                     ),
                 ).toEqual('Prefix else Postfix');
             });
@@ -298,7 +298,7 @@ describe('Conditions', () => {
                     conditions(
                         'Prefix {% if user %} Before nested if {% if user.name == \'Alice\' %} nested if ' +
                         '{% endif %} After nested if {% endif %} Postfix',
-                        {user: {name: 'Alice'}},
+                        {vars: {user: {name: 'Alice'}}},
                     ),
                 ).toEqual('Prefix Before nested if nested if After nested if Postfix');
             });
@@ -308,7 +308,7 @@ describe('Conditions', () => {
                     conditions(
                         'Prefix {% if user %} Before nested if {% if user.name == \'Alice\' %} nested if ' +
                         '{% endif %} After nested if {% endif %} Postfix',
-                        {user: {name: 'Bob'}},
+                        {vars: {user: {name: 'Bob'}}},
                     ),
                 ).toEqual('Prefix Before nested if  After nested if Postfix');
             });
@@ -321,7 +321,7 @@ describe('Conditions', () => {
                 conditions(
                     'Prefix {% if yandex %} if {% elsif user.name == \'Bob\' %} Bob ' +
                     '{% elsif user.name == \'Alice\' %} Alice {% endif %} Postfix',
-                    {user: {name: 'Alice'}},
+                    {vars: {user: {name: 'Alice'}}},
                 ),
             ).toEqual('Prefix Alice Postfix');
         });

--- a/test/liquid/cycles.test.js
+++ b/test/liquid/cycles.test.js
@@ -28,7 +28,7 @@ describe('Cycles', () => {
             expect(
                 liquid(
                     'Prefix {% for user in users %} {{user}} {% endfor %} Postfix',
-                    vars,
+                    {vars},
                 ),
             ).toEqual('Prefix Alice Ivan Petr Postfix');
         });
@@ -37,7 +37,7 @@ describe('Cycles', () => {
             expect(
                 liquid(
                     'Prefix {% for user1 in users %} {% for user2 in users %} {{user1}}+{{user2}} {% endfor %} {% endfor %} Postfix',
-                    vars,
+                    {vars},
                 ),
             ).toEqual('Prefix Alice+Alice Alice+Ivan Alice+Petr Ivan+Alice Ivan+Ivan Ivan+Petr Petr+Alice Petr+Ivan Petr+Petr Postfix');
         });
@@ -50,7 +50,7 @@ describe('Cycles', () => {
                     '{{user}}\n' +
                     '{% endfor %}\n' +
                     'Postfix',
-                    vars,
+                    {vars},
                 ),
             ).toEqual(
                 'Prefix\n' +
@@ -109,7 +109,7 @@ Postfix
             expect(
                 liquid(
                     input,
-                    vars,
+                    {vars},
                 ),
             ).toEqual(result);
         });
@@ -124,7 +124,7 @@ Postfix
                     '{% endfor %}\n' +
                     '{% endfor %}\n' +
                     'Postfix',
-                    vars,
+                    {vars},
                 ),
             ).toEqual(
                 'Prefix\n' +
@@ -148,7 +148,7 @@ Postfix
             expect(
                 liquid(
                     'Prefix {% for user in users2 %} {% if needCapitalize %} {{user | capitalize}}+{{user2}} {% else %} {{user}} {% endif %} {% endfor %} Postfix',
-                    vars,
+                    {vars},
                 ),
             ).toEqual('Prefix Alice+Alex Ivan+Alex Petr+Alex Postfix');
         });

--- a/test/liquid/filters.test.js
+++ b/test/liquid/filters.test.js
@@ -3,25 +3,25 @@ const substitutions = require('../../lib/liquid/substitutions');
 describe('Filters', () => {
     test('capitalize', () => {
         expect(
-            substitutions('Hello {{ user.name | capitalize }}!', {user: {name: 'alice'}}),
+            substitutions('Hello {{ user.name | capitalize }}!', {vars: {user: {name: 'alice'}}}),
         ).toEqual('Hello Alice!');
     });
 
     test('length', () => {
         expect(
-            substitutions('Users count: {{ users | length }}', {users: ['Alice', 'Mark']}),
+            substitutions('Users count: {{ users | length }}', {vars: {users: ['Alice', 'Mark']}}),
         ).toEqual('Users count: 2');
     });
 
     describe('length', () => {
         test('Test1', () => {
             expect(
-                substitutions('Users count: {{ users | length }}', {users: ['Alice', 'Mark']}),
+                substitutions('Users count: {{ users | length }}', {vars: {users: ['Alice', 'Mark']}}),
             ).toEqual('Users count: 2');
         });
         test('Test2', () => {
             expect(
-                substitutions('{{ test | length }}', {test: 'hello world'}),
+                substitutions('{{ test | length }}', {vars: {test: 'hello world'}}),
             ).toEqual('11');
         });
     });
@@ -29,7 +29,7 @@ describe('Filters', () => {
     describe('escapeMarkdown', () => {
         test('Test1', () => {
             expect(
-                substitutions('{{ test | escapeMarkdown }}', {test: '`*_{}[]()#+-.!|'}),
+                substitutions('{{ test | escapeMarkdown }}', {vars: {test: '`*_{}[]()#+-.!|'}}),
             ).toEqual('\\`\\*\\_\\{\\}\\[\\]\\(\\)\\#\\+\\-\\.\\!\\|');
         });
     });
@@ -37,22 +37,22 @@ describe('Filters', () => {
     describe('There is no a space after and before the filter operator. It can only be a variable.', () => {
         test('Existent filter and non-existent variable', () => {
             expect(
-                substitutions('{{ test|capitalize }}', {'test|capitalize': 'Alice', test: 'mark'}),
+                substitutions('{{ test|capitalize }}', {vars:  {'test|capitalize': 'Alice', test: 'mark'}}),
             ).toEqual('Alice');
         });
         test('Non-existent filter and non-existent variable', () => {
             expect(
-                substitutions('{{ test|testFilter }}', {'test|testFilter': 'Alice', test: 'mark'}),
+                substitutions('{{ test|testFilter }}', {vars: {'test|testFilter': 'Alice', test: 'mark'}}),
             ).toEqual('Alice');
         });
         test('Non-existent filter and existent variable', () => {
             expect(
-                substitutions('{{ test|test }}', {'test|test': 'Alice', test: 'mark'}),
+                substitutions('{{ test|test }}', {vars: {'test|test': 'Alice', test: 'mark'}}),
             ).toEqual('Alice');
         });
         test('Existent filter and existent variable', () => {
             expect(
-                substitutions('{{ test|capitalize }}', {'test|capitalize': 'Alice', test: 'mark'}),
+                substitutions('{{ test|capitalize }}', {vars: {'test|capitalize': 'Alice', test: 'mark'}}),
             ).toEqual('Alice');
         });
     });
@@ -60,12 +60,12 @@ describe('Filters', () => {
     describe('There is a space after and beefore filter operator. It can only be a filter.', () => {
         test('Existent filter', () => {
             expect(
-                substitutions('{{ test | capitalize }}', {test: 'mark'}),
+                substitutions('{{ test | capitalize }}', {vars: {test: 'mark'}}),
             ).toEqual('Mark');
         });
         test('Non-existent filter', () => {
             expect(
-                substitutions('{{ test | testFilter }}', {test: 'Alice'}),
+                substitutions('{{ test | testFilter }}', {vars: {test: 'Alice'}}),
             ).toEqual('{{ test | testFilter }}');
         });
     });
@@ -73,12 +73,12 @@ describe('Filters', () => {
     describe('There is a space after the filter operator. It can only be a filter.', () => {
         test('Existent filter', () => {
             expect(
-                substitutions('{{ test| capitalize }}', {test: 'mark'}),
+                substitutions('{{ test| capitalize }}', {vars: {test: 'mark'}}),
             ).toEqual('Mark');
         });
         test('Non-existent filter', () => {
             expect(
-                substitutions('{{ test| testFilter }}', {test: 'Alice'}),
+                substitutions('{{ test| testFilter }}', {vars: {test: 'Alice'}}),
             ).toEqual('{{ test| testFilter }}');
         });
     });
@@ -86,12 +86,12 @@ describe('Filters', () => {
     describe('There is a space before the filter operator. It can only be a filter.', () => {
         test('Existent filter', () => {
             expect(
-                substitutions('{{ test |capitalize }}', {test: 'mark'}),
+                substitutions('{{ test |capitalize }}', {vars: {test: 'mark'}}),
             ).toEqual('Mark');
         });
         test('Non-existent filter', () => {
             expect(
-                substitutions('{{ test |testFilter }}', {test: 'Alice'}),
+                substitutions('{{ test |testFilter }}', {vars: {test: 'Alice'}}),
             ).toEqual('{{ test |testFilter }}');
         });
     });

--- a/test/liquid/functions.test.js
+++ b/test/liquid/functions.test.js
@@ -4,12 +4,12 @@ describe('Functions', () => {
     describe('slice', () => {
         test('Test 1', () => {
             expect(
-                substitutions('Hello M{{ user.name.slice(1) }}!', {user: {name: 'Pasha'}}),
+                substitutions('Hello M{{ user.name.slice(1) }}!', {vars: {user: {name: 'Pasha'}}}),
             ).toEqual('Hello Masha!');
         });
         test('Test 2', () => {
             expect(
-                substitutions('Hello M{{ user.name.slice(1, 2) }}sha!', {user: {name: 'Pasha'}}),
+                substitutions('Hello M{{ user.name.slice(1, 2) }}sha!', {vars: {user: {name: 'Pasha'}}}),
             ).toEqual('Hello Masha!');
         });
         test('Test 3', () => {

--- a/test/liquid/substitutions.test.js
+++ b/test/liquid/substitutions.test.js
@@ -3,7 +3,7 @@ const substitutions = require('../../lib/liquid/substitutions');
 describe('Substitutions', () => {
     test('Should substitute to inline text', () => {
         expect(
-            substitutions('Hello {{ user.name }}!', {user: {name: 'Alice'}}),
+            substitutions('Hello {{ user.name }}!', {vars: {user: {name: 'Alice'}}}),
         ).toEqual('Hello Alice!');
     });
     test('Should not substitute variables start with dot', () => {


### PR DESCRIPTION
Как используется в yfm-docs: https://github.com/yandex-cloud/yfm-docs/pull/65

Есть preprocessLintRules, запускаются до liquid и плагинов
Остальные правила используется во время прогона liquid и плагинов
transform принимает lintOptions,  обьект, где ключ - название правила, а значение объект с его опциями
lintOptions содержит правила для preprocessLintRules, liquidLintRules и pluginsLintRules

Некоторые ошибки считаю следует оставлять неотключаемыми и не переопределяемыми. Например, плагин links содержит такие ошибки, игнорирование которых не может привести к чему-то хорошему, но для примера они сейчас добавлены как отключаемые. Планируется добавлять отключаемые правила для новых проверок