### PR TITLE
revert: remove hljs class from expected result in a table test

### DIFF
--- a/test/table.test.js
+++ b/test/table.test.js
@@ -254,7 +254,7 @@ describe('Table plugin', () => {
             '<tr>\n' +
             '<td>1</td>\n' +
             '<td>\n' +
-            '<pre><code class="hljs">|===\n' +
+            '<pre><code>|===\n' +
             '| 4\n' +
             '| 5\n' +
             '\n' +


### PR DESCRIPTION
highlight.js is a peer dependency, the class will be added if this
dependency is installed