### PR TITLE
feat: add delimeter options in attrs plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,6 +22,7 @@ function transform(originInput, opts = {}) {
     const {
         vars = {}, path, extractTitle: extractTitleOption, needTitle,
         allowHTML = false, linkify = false, breaks = true, conditionsInCode = false, disableLiquid = false,
+        leftDelimiter = '{', rightDelimiter = '}',
         isLiquided = false,
         plugins = [meta, deflist, cut, notes, anchors, tabs, code, sup, video], highlightLangs = {},
         ...customOptions
@@ -42,7 +43,7 @@ function transform(originInput, opts = {}) {
     const highlight = makeHighlight(highlightLangs);
     const md = new MarkdownIt({html: allowHTML, linkify, highlight, breaks});
     // Need for ids of headers
-    md.use(attrs);
+    md.use(attrs, {leftDelimiter, rightDelimiter});
     plugins.forEach((plugin) => md.use(plugin, pluginOptions));
 
     try {


### PR DESCRIPTION
Added markdown-it-attrs delimeter [options](https://github.com/arve0/markdown-it-attrs#custom-delimiters) 