### PR TITLE
Issues were fixed with includes urls + \r\n on windows

### DIFF
--- a/lib/plugins/anchors/collect.js
+++ b/lib/plugins/anchors/collect.js
@@ -1,5 +1,6 @@
-const slugify = require('slugify');
 const _ = require('lodash');
+const {sep} = require('path');
+const slugify = require('slugify');
 
 const {getSinglePageAnchorId, resolveRelativePath} = require('../../utilsFS');
 const {transformLinkToOriginalArticle} = require('../../utils');
@@ -7,6 +8,7 @@ const {
     CUSTOM_ID_REGEXP,
     CUSTOM_ID_EXCEPTION,
 } = require('./constants');
+const {сarriage} = require('../utils');
 
 /* eslint-disable max-len */
 /* If the singlePage option is passed in the options:
@@ -22,7 +24,7 @@ const {
 const collect = (input, options) => {
     const {root, path, singlePage} = options;
 
-    if (!singlePage || path.includes('_includes/')) {
+    if (!singlePage || path.includes(`_includes${sep}`)) {
         return;
     }
 
@@ -30,7 +32,7 @@ const collect = (input, options) => {
     const pageId = getSinglePageAnchorId({root, currentPath});
     let needToSetPageId = true;
     let needToSetOriginalPathAttr = true;
-    const lines = input.split('\n');
+    const lines = input.split(сarriage);
     let i = 0;
     const HEADER_LINK_REGEXP = /^(?<headerLevel>#+)\s(?<headerContent>.+)$/i;
 
@@ -88,7 +90,7 @@ const collect = (input, options) => {
     }
 
     // eslint-disable-next-line consistent-return
-    return lines.join('\n');
+    return lines.join(сarriage);
 };
 
 module.exports = collect;

--- a/lib/plugins/links/collect.js
+++ b/lib/plugins/links/collect.js
@@ -1,5 +1,6 @@
 const MarkdownIt = require('markdown-it');
 const url = require('url');
+const {sep} = require('path');
 const {
     isLocalUrl,
 } = require('../../utils');
@@ -28,7 +29,7 @@ const collect = (input, options) => {
     let result = input;
 
     /* Syntax "{% include [Text](_includes/file.md) %}" is parsed as link. Need to ignore errors */
-    const needSkipLinkFn = (href) => href.includes('_includes/');
+    const needSkipLinkFn = (href) => href.includes(`_includes${sep}`);
     const transformLink = (href) => href;
     const md = new MarkdownIt()
         .use(index, {...options, transformLink, needSkipLinkFn});
@@ -50,7 +51,7 @@ const collect = (input, options) => {
 
                 const linkToken = childrenTokens[j];
                 const href = linkToken.attrGet('href');
-                const isIncludeLink = resolveRelativePath(startPath, href).includes('_includes/');
+                const isIncludeLink = resolveRelativePath(startPath, decodeURI(href)).includes(`_includes${sep}`);
 
                 if (!href || !isLocalUrl(href) || isIncludeLink) {
                     j++;

--- a/lib/plugins/links/index.js
+++ b/lib/plugins/links/index.js
@@ -68,7 +68,7 @@ function processLink(state, tokens, idx, opts) {
     const currentPath = state.env.path || startPath;
     const linkToken = tokens[idx];
     const nextToken = tokens[idx + 1];
-    let href = linkToken.attrGet('href');
+    let href = decodeURI(linkToken.attrGet('href'));
 
     if (!href) {
         log.error(`Empty link in ${bold(startPath)}`);

--- a/lib/plugins/utils.js
+++ b/lib/plugins/utils.js
@@ -1,4 +1,5 @@
 const {bold} = require('chalk');
+const {platform} = require('process');
 
 const nestedCloseTokenIdxFactory = (tokenName, matchOpenToken, matchCloseToken) => (tokens, idx, path, log) => {
     let level = 0;
@@ -21,4 +22,6 @@ const nestedCloseTokenIdxFactory = (tokenName, matchOpenToken, matchCloseToken) 
     return null;
 };
 
-module.exports = {nestedCloseTokenIdxFactory};
+const сarriage = platform === 'win32' ? '\r\n' : '\n';
+
+module.exports = {nestedCloseTokenIdxFactory, сarriage};


### PR DESCRIPTION
md.parser преобразует путь <path>\<file_name>.md как <path>%С5<file_name>.md
%С5 - это backslash, который encripted