### PR TITLE
DOCSTOOLS-1128: don't apply styles to svg inside katex

### DIFF
--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -96,6 +96,10 @@
         height: auto;
     }
 
+    .katex svg {
+        height: initial;
+    }
+
     img + small {
         display: block;
     }
@@ -263,11 +267,11 @@
         ol {
             list-style-type: none;
             counter-reset: list;
-    
+
             & > li {
                 position: relative;
                 counter-increment: list;
-    
+
                 &::before {
                     position: absolute;
                     right: 100%;


### PR DESCRIPTION
## Now
<img width="965" alt="Screen Shot 2022-04-21 at 3 50 01 PM" src="https://user-images.githubusercontent.com/62902338/164461731-bbb1e84a-0d56-4d0d-9b3d-19c420166fcd.png">

## After this change
<img width="1021" alt="Screen Shot 2022-04-21 at 3 52 02 PM" src="https://user-images.githubusercontent.com/62902338/164462038-40180c99-4f7b-4768-b6c1-f826f84a4aa0.png">

## Without styles on svg
<img width="1006" alt="Screen Shot 2022-04-21 at 3 50 20 PM" src="https://user-images.githubusercontent.com/62902338/164461749-cb0ee476-c4b5-496c-aefe-78b69f6b68ad.png">
