### PR TITLE
fix: update markdownlint up to 0.25.1 to avoid Regular Expression Denial of Service (ReDoS) vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5298,25 +5298,11 @@
       }
     },
     "markdownlint": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.23.1.tgz",
-      "integrity": "sha512-iOEwhDfNmq2IJlaA8mzEkHYUi/Hwoa6Ss+HO5jkwUR6wQ4quFr0WzSx+Z9rsWZKUaPbyirIdL1zGmJRkWawr4Q==",
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
       "requires": {
-        "markdown-it": "12.0.4"
-      },
-      "dependencies": {
-        "markdown-it": {
-          "version": "12.0.4",
-          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.0.4.tgz",
-          "integrity": "sha512-34RwOXZT8kyuOJy25oJNJoulO8L0bTHYWXcdZBYZqFnjIy3NgjeoM3FmPXIOFQ26/lSHYMr8oc62B6adxXcb3Q==",
-          "requires": {
-            "argparse": "^2.0.1",
-            "entities": "~2.1.0",
-            "linkify-it": "^3.0.1",
-            "mdurl": "^1.0.1",
-            "uc.micro": "^1.0.5"
-          }
-        }
+        "markdown-it": "12.3.2"
       }
     },
     "markdownlint-rule-helpers": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "markdown-it-deflist": "2.1.0",
     "markdown-it-meta": "0.0.1",
     "markdown-it-sup": "1.0.0",
-    "markdownlint": "0.23.1",
+    "markdownlint": "0.25.1",
     "markdownlint-rule-helpers": "0.14.0",
     "postcss": "8.4.5",
     "slugify": "1.6.5"


### PR DESCRIPTION
This package `@doc-tools/transform` depends on `markdownlint@0.23.1`, which [depends on](https://github.com/DavidAnson/markdownlint/blob/v0.23.1/package.json#L39) `markdown-it@12.0.4`. And `markdown-it` of this version has ReDoS vulnerability, that was fixed in this commit: https://github.com/markdown-it/markdown-it/commit/ffc49ab46b5b751cd2be0aabb146f2ef84986101

So I updated markdownlint to the latest version, for getting `markdown-it@12.3.2` where the security issue was fixed.