### PR TITLE
feat: add file plugin

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
+/* eslint-env node */
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
-// eslint-disable-next-line no-undef
 module.exports = {
     roots: ['<rootDir>/test'],
     preset: 'ts-jest',

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-
+/* eslint-env node */
 
 module.exports = {
     plugins: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,5 @@
+/* eslint-env node */
+
 import {nodeResolve} from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';

--- a/src/scss/_file.scss
+++ b/src/scss/_file.scss
@@ -1,0 +1,35 @@
+@import 'variables';
+
+$defaultIcon: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAzODQgNTEyIj48cGF0aCBmaWxsPSJjdXJyZW50Q29sb3IiIGQ9Ik0zNjkuOSA5Ny45TDI4NiAxNEMyNzcgNSAyNjQuOC0uMSAyNTIuMS0uMUg0OEMyMS41IDAgMCAyMS41IDAgNDh2NDE2YzAgMjYuNSAyMS41IDQ4IDQ4IDQ4aDI4OGMyNi41IDAgNDgtMjEuNSA0OC00OFYxMzEuOWMwLTEyLjctNS4xLTI1LTE0LjEtMzR6bS0yMi42IDIyLjdjMi4xIDIuMSAzLjUgNC42IDQuMiA3LjRIMjU2VjMyLjVjMi44LjcgNS4zIDIuMSA3LjQgNC4ybDgzLjkgODMuOXpNMzM2IDQ4MEg0OGMtOC44IDAtMTYtNy4yLTE2LTE2VjQ4YzAtOC44IDcuMi0xNiAxNi0xNmgxNzZ2MTA0YzAgMTMuMyAxMC43IDI0IDI0IDI0aDEwNHYzMDRjMCA4LjgtNy4yIDE2LTE2IDE2em0tNDgtMjQ0djhjMCA2LjYtNS40IDEyLTEyIDEySDEwOGMtNi42IDAtMTItNS40LTEyLTEydi04YzAtNi42IDUuNC0xMiAxMi0xMmgxNjhjNi42IDAgMTIgNS40IDEyIDEyem0wIDY0djhjMCA2LjYtNS40IDEyLTEyIDEySDEwOGMtNi42IDAtMTItNS40LTEyLTEydi04YzAtNi42IDUuNC0xMiAxMi0xMmgxNjhjNi42IDAgMTIgNS40IDEyIDEyem0wIDY0djhjMCA2LjYtNS40IDEyLTEyIDEySDEwOGMtNi42IDAtMTItNS40LTEyLTEydi04YzAtNi42IDUuNC0xMiAxMi0xMmgxNjhjNi42IDAgMTIgNS40IDEyIDEyeiIvPjwvc3ZnPg==");
+
+/**
+    Public CSS variables:
+    --yfm-file-icon             sets file icon image
+    --yfm-file-icon-color       sets file icon color
+*/
+
+.yfm-file {
+    &__icon {
+        ---yfm-file-icon-img: var(--yfm-file-icon, #{$defaultIcon});
+
+        display: inline-block;
+        user-select: none;
+
+        width: 16px;
+        margin: 0 2px;
+
+        color: var(--yfm-file-icon-color, #{$textColor});
+        background-color: currentColor;
+        background-repeat: no-repeat;
+        background-position: 50%;
+        background-size: 100%;
+
+        mask-image: var(---yfm-file-icon-img);
+        mask-position: center;
+        mask-repeat: no-repeat;
+
+        &::before {
+            content: '\a0';
+        }
+    }
+}

--- a/src/scss/yfm.scss
+++ b/src/scss/yfm.scss
@@ -6,3 +6,4 @@
 @import 'code';
 @import 'print';
 @import 'cut';
+@import 'file';

--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -12,6 +12,7 @@ import anchors from './plugins/anchors';
 import code from './plugins/code';
 import cut from './plugins/cut';
 import deflist from './plugins/deflist';
+import file from './plugins/file';
 import meta from './plugins/meta';
 import sup from './plugins/sup';
 import tabs from './plugins/tabs';
@@ -66,7 +67,20 @@ function transform(originInput: string, opts: OptionsType = {}): OutputType {
         leftDelimiter = '{',
         rightDelimiter = '}',
         isLiquided = false,
-        plugins = [meta, deflist, cut, notes, anchors, tabs, code, sup, video, monospace, yfmTable],
+        plugins = [
+            meta,
+            deflist,
+            cut,
+            notes,
+            anchors,
+            tabs,
+            code,
+            sup,
+            video,
+            monospace,
+            yfmTable,
+            file,
+        ],
         highlightLangs = {},
         ...customOptions
     } = opts;

--- a/src/transform/plugins/file/README.md
+++ b/src/transform/plugins/file/README.md
@@ -1,0 +1,34 @@
+# YFM File plugin
+
+```md
+%file(src="path/to/file" name='readme.md')
+
+==>
+
+<a href="path/to/file" download="readme.md" class="yfm-file"><span class="yfm-file__icon"></span>readme.md</a>
+```
+
+## Attributes
+
+|Name|Required|Description|
+|---|---|---|
+|`src`|yes|URL of the file. Will be mapped to [`href` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-href)|
+|`name`|yes|Name of the file. Will be mapped to [`download` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download)|
+|`lang`|-|Language of the file content. Will be mapped to [`hreflang` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-hreflang)|
+|`referrerpolicy`|-|[`referrerpolicy` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-referrerpolicy)|
+|`rel`|-|[`rel` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-rel)|
+|`target`|-|[`target` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target)|
+|`type`|-|[`type` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-type)|
+
+> _Note: other attributes will be ignored_
+
+## Plugin options
+
+|Name|Type|Description|
+|---|---|---|
+|`fileExtraAttrs`|`[string, string][]`|Adds additional attributes to rendered hyperlink|
+
+## CSS public variables
+
+* `--yfm-file-icon` – sets custom file icon image
+* `--yfm-file-icon-color` – sets custom file icon color

--- a/src/transform/plugins/file/README.md
+++ b/src/transform/plugins/file/README.md
@@ -1,7 +1,7 @@
 # YFM File plugin
 
 ```md
-%file(src="path/to/file" name='readme.md')
+{% file src="path/to/file" name='readme.md' %}
 
 ==>
 

--- a/src/transform/plugins/file/const.ts
+++ b/src/transform/plugins/file/const.ts
@@ -1,0 +1,46 @@
+export enum FileSpecialAttr {
+    Src = 'src',
+    Name = 'name',
+    Lang = 'lang',
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attributes
+export enum LinkHtmlAttr {
+    Download = 'download',
+    Href = 'href',
+    HrefLang = 'hreflang',
+    Media = 'media',
+    Ping = 'ping',
+    ReferrerPolicy = 'referrerpolicy',
+    Rel = 'rel',
+    Target = 'target',
+    Type = 'type',
+}
+
+export const FILE_TO_LINK_ATTRS_MAP: Record<FileSpecialAttr, LinkHtmlAttr> = {
+    [FileSpecialAttr.Src]: LinkHtmlAttr.Href,
+    [FileSpecialAttr.Name]: LinkHtmlAttr.Download,
+    [FileSpecialAttr.Lang]: LinkHtmlAttr.HrefLang,
+};
+
+export const RULE_NAME = 'yfm_file_inline';
+export const KNOWN_ATTRS: readonly string[] = [
+    FileSpecialAttr.Src,
+    FileSpecialAttr.Name,
+    FileSpecialAttr.Lang,
+    LinkHtmlAttr.ReferrerPolicy,
+    LinkHtmlAttr.Rel,
+    LinkHtmlAttr.Target,
+    LinkHtmlAttr.Type,
+];
+export const REQUIRED_ATTRS: readonly string[] = [FileSpecialAttr.Src, FileSpecialAttr.Name];
+
+export const FILE_TOKEN = 'yfm_file';
+
+export const PREFIX = '%file';
+export const PREFIX_LENGTH = PREFIX.length;
+
+export enum FileClassName {
+    Link = 'yfm-file',
+    Icon = 'yfm-file__icon',
+}

--- a/src/transform/plugins/file/const.ts
+++ b/src/transform/plugins/file/const.ts
@@ -37,7 +37,7 @@ export const REQUIRED_ATTRS: readonly string[] = [FileSpecialAttr.Src, FileSpeci
 
 export const FILE_TOKEN = 'yfm_file';
 
-export const PREFIX = '%file';
+export const PREFIX = '{% file ';
 export const PREFIX_LENGTH = PREFIX.length;
 
 export enum FileClassName {

--- a/src/transform/plugins/file/file.ts
+++ b/src/transform/plugins/file/file.ts
@@ -29,10 +29,10 @@ export const fileParser = (_md: MarkdownIt, opts?: FileOptions): ParserInline.Ru
     return (state, silent) => {
         if (state.src.substring(state.pos, state.pos + PREFIX_LENGTH) !== PREFIX) return false;
 
-        // the rest of line after '%file'
+        // the rest of line after '{% file '
         const searchStr = state.src.slice(state.pos + PREFIX_LENGTH, state.posMax);
-        // loking for pattern '(src="..." name="..." etc="value")'
-        const matchResult = searchStr.match(/^\(((?:\s*\w+=(?:"[^"]+"|'[^']+')\s*)+)\)/);
+        // loking for pattern 'src="..." name="..." etc="value" %}'
+        const matchResult = searchStr.match(/^((?:\s*\w+=(?:"[^"]+"|'[^']+')\s)+)\s*%}/);
         if (!matchResult) return false;
 
         const paramsGroupLength = matchResult[0].length; // '(src="..." name="...")'.length

--- a/src/transform/plugins/file/file.ts
+++ b/src/transform/plugins/file/file.ts
@@ -1,0 +1,82 @@
+import type MarkdownIt from 'markdown-it';
+import type ParserInline from 'markdown-it/lib/parser_inline';
+import type Renderer from 'markdown-it/lib/renderer';
+
+import {
+    FileClassName,
+    FileSpecialAttr,
+    FILE_TOKEN,
+    FILE_TO_LINK_ATTRS_MAP,
+    KNOWN_ATTRS,
+    PREFIX,
+    PREFIX_LENGTH,
+    REQUIRED_ATTRS,
+} from './const';
+
+export type FileOptions = {
+    fileExtraAttrs: [string, string][];
+};
+
+export const fileRenderer = (md: MarkdownIt): Renderer.RenderRule => {
+    const iconHtml = `<span class="${md.utils.escapeHtml(FileClassName.Icon)}"></span>`;
+    return (tokens, idx, _opts, _env, self) => {
+        const token = tokens[idx];
+        return `<a${self.renderAttrs(token)}>${iconHtml}${md.utils.escapeHtml(token.content)}</a>`;
+    };
+};
+
+export const fileParser = (_md: MarkdownIt, opts?: FileOptions): ParserInline.RuleInline => {
+    return (state, silent) => {
+        if (state.src.substring(state.pos, state.pos + PREFIX_LENGTH) !== PREFIX) return false;
+
+        // the rest of line after '%file'
+        const searchStr = state.src.slice(state.pos + PREFIX_LENGTH, state.posMax);
+        // loking for pattern '(src="..." name="..." etc="value")'
+        const matchResult = searchStr.match(/^\(((?:\s*\w+=(?:"[^"]+"|'[^']+')\s*)+)\)/);
+        if (!matchResult) return false;
+
+        const paramsGroupLength = matchResult[0].length; // '(src="..." name="...")'.length
+        const paramsStr = matchResult[1]; // 'src="..." name="..."'
+
+        // find pairs of key="foo" or key='bar'
+        const params = paramsStr.match(/\w+=(?:"[^"]+"|'[^']+')/g);
+        if (!params) return false;
+
+        const attrsObj: Record<string, string> = {};
+        params.forEach((param) => {
+            const indexKey = param.indexOf('=');
+            const key = param.slice(0, indexKey);
+            const value = param.slice(indexKey + 2, -1);
+            if (KNOWN_ATTRS.includes(key) && value) {
+                attrsObj[key] = value;
+            }
+        });
+
+        const hasAllRequiredAttrs = REQUIRED_ATTRS.every((attr) => attr in attrsObj);
+        if (!hasAllRequiredAttrs) return false;
+
+        if (!silent) {
+            const token = state.push(FILE_TOKEN, '', 0);
+            token.block = false;
+            token.markup = PREFIX;
+            token.content = attrsObj[FileSpecialAttr.Name];
+            token.attrs = Object.entries(attrsObj);
+            token.attrSet('class', FileClassName.Link);
+
+            for (const attr of token.attrs) {
+                if (attr[0] in FILE_TO_LINK_ATTRS_MAP) {
+                    attr[0] = FILE_TO_LINK_ATTRS_MAP[attr[0] as FileSpecialAttr];
+                }
+            }
+
+            if (Array.isArray(opts?.fileExtraAttrs)) {
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                token.attrs.push(...opts!.fileExtraAttrs);
+            }
+        }
+
+        state.pos = state.pos + PREFIX_LENGTH + paramsGroupLength;
+
+        return true;
+    };
+};

--- a/src/transform/plugins/file/index.ts
+++ b/src/transform/plugins/file/index.ts
@@ -1,0 +1,10 @@
+import type {PluginWithOptions} from 'markdown-it';
+import {FILE_TOKEN, RULE_NAME} from './const';
+import {FileOptions, fileParser, fileRenderer} from './file';
+
+const filePlugin: PluginWithOptions<FileOptions> = (md, opts) => {
+    md.inline.ruler.push(RULE_NAME, fileParser(md, opts));
+    md.renderer.rules[FILE_TOKEN] = fileRenderer(md);
+};
+
+export = filePlugin;

--- a/test/file.test.ts
+++ b/test/file.test.ts
@@ -1,10 +1,17 @@
-import MarkdownIt from 'markdown-it';
-import file from '../src/transform/plugins/file';
+import yfmTransform from '../src/transform';
 import type {FileOptions} from '../src/transform/plugins/file/file';
 
 const transform = (text: string, opts?: FileOptions): string => {
-    const md = new MarkdownIt().use(file, opts);
-    return md.render(text);
+    const {
+        result: {html},
+    } = yfmTransform(text, {
+        // override the default markdown-it-attrs delimiters,
+        // to make it easier to check html for non-valid file markup
+        leftDelimiter: '[',
+        rightDelimiter: ']',
+        ...opts,
+    });
+    return html;
 };
 
 const iconHtml = '<span class="yfm-file__icon"></span>';

--- a/test/file.test.ts
+++ b/test/file.test.ts
@@ -1,0 +1,136 @@
+import transform from '../src/transform';
+import file from '../src/transform/plugins/file';
+import type {FileOptions} from '../src/transform/plugins/file/file';
+
+const transformYfm = (text: string, opts?: FileOptions) => {
+    const {
+        result: {html},
+    } = transform(text, {
+        plugins: [file],
+        ...opts,
+    });
+    return html;
+};
+
+const iconHtml = '<span class="yfm-file__icon"></span>';
+
+describe('File plugin', () => {
+    it('should render file', () => {
+        expect(transformYfm('%file(src="../file" name="file.txt")')).toBe(
+            `<p><a href="../file" download="file.txt" class="yfm-file">${iconHtml}file.txt</a></p>\n`,
+        );
+    });
+
+    it('should ignore file markup without params', () => {
+        expect(transformYfm('%file()')).toBe('<p>%file()</p>\n');
+    });
+
+    it('should not render file without all required attrs', () => {
+        expect(transformYfm('%file(src="../file")')).toBe(
+            '<p>%file(src=&quot;../file&quot;)</p>\n',
+        );
+        expect(transformYfm('%file(name="file.txt")')).toBe(
+            '<p>%file(name=&quot;file.txt&quot;)</p>\n',
+        );
+    });
+
+    it('should render file with text before', () => {
+        expect(transformYfm('download it %file(src="../file" name="file.txt")')).toBe(
+            `<p>download it <a href="../file" download="file.txt" class="yfm-file">${iconHtml}file.txt</a></p>\n`,
+        );
+    });
+
+    it('should render file with text after', () => {
+        expect(transformYfm('%file(src="../file" name="file.txt") don\'t download it')).toBe(
+            `<p><a href="../file" download="file.txt" class="yfm-file">${iconHtml}file.txt</a> don't download it</p>\n`,
+        );
+    });
+
+    it('should render file between text', () => {
+        expect(transformYfm('text %file(src="../file" name="file.txt") text')).toBe(
+            `<p>text <a href="../file" download="file.txt" class="yfm-file">${iconHtml}file.txt</a> text</p>\n`,
+        );
+    });
+
+    it('should map all specific file attrs to link html attrs', () => {
+        expect(transformYfm('%file(src="../file2" name="file2.txt" lang="en")')).toBe(
+            `<p><a href="../file2" download="file2.txt" hreflang="en" class="yfm-file">${iconHtml}file2.txt</a></p>\n`,
+        );
+    });
+
+    it('should pass allowed link html attrs', () => {
+        expect(
+            transformYfm(
+                '%file(src="../file1" name="file1.txt" referrerpolicy="origin" rel="help" target="_top" type="text/css")',
+            ),
+        ).toBe(
+            `<p><a href="../file1" download="file1.txt" referrerpolicy="origin" rel="help" target="_top" type="text/css" class="yfm-file">${iconHtml}file1.txt</a></p>\n`,
+        );
+    });
+
+    it('should ignore unknown attrs', () => {
+        expect(transformYfm('%file(src="../file" name="file.txt" foo="1" bar="2" baz="3")')).toBe(
+            `<p><a href="../file" download="file.txt" class="yfm-file">${iconHtml}file.txt</a></p>\n`,
+        );
+    });
+
+    it('should add extra attrs', () => {
+        expect(
+            transformYfm('%file(src="../file" name="file.txt")', {
+                fileExtraAttrs: [['data-yfm-file', 'yes']],
+            }),
+        ).toBe(
+            `<p><a href="../file" download="file.txt" class="yfm-file" data-yfm-file="yes">${iconHtml}file.txt</a></p>\n`,
+        );
+    });
+
+    it('should parse attrs with single quotes', () => {
+        expect(transformYfm("%file(src='index.txt' name='index.html')")).toBe(
+            `<p><a href="index.txt" download="index.html" class="yfm-file">${iconHtml}index.html</a></p>\n`,
+        );
+    });
+
+    it('should include parentheses in double quotes', () => {
+        expect(transformYfm('%file(src="in(de)x.txt" name=")))index(((.html")')).toBe(
+            `<p><a href="in(de)x.txt" download=")))index(((.html" class="yfm-file">${iconHtml})))index(((.html</a></p>\n`,
+        );
+    });
+
+    it('should ignore parentheses after file markup', () => {
+        expect(transformYfm('%file(src="index.txt" name="index.html")))')).toBe(
+            `<p><a href="index.txt" download="index.html" class="yfm-file">${iconHtml}index.html</a>))</p>\n`,
+        );
+    });
+
+    it('should ignore parentheses after file markup [2]', () => {
+        expect(transformYfm('%file(src="index.txt" name="index.html") some text (:)')).toBe(
+            `<p><a href="index.txt" download="index.html" class="yfm-file">${iconHtml}index.html</a> some text (:)</p>\n`,
+        );
+    });
+
+    it('should escape attrs', () => {
+        expect(transformYfm('%file(src="ind<ex.txt" name=\'ind"ex.ht&ml\')')).toBe(
+            `<p><a href="ind&lt;ex.txt" download="ind&quot;ex.ht&amp;ml" class="yfm-file">${iconHtml}ind&quot;ex.ht&amp;ml</a></p>\n`,
+        );
+    });
+
+    it('should allow quoutes in attribute value', () => {
+        expect(transformYfm('%file(src="ind\'ex.txt" name=\'ind"ex.html\')')).toBe(
+            `<p><a href="ind'ex.txt" download="ind&quot;ex.html" class="yfm-file">${iconHtml}ind&quot;ex.html</a></p>\n`,
+        );
+    });
+
+    it('should render file with extra spaces around attrs', () => {
+        expect(
+            transformYfm('%file(  src="index.txt"   name="index.html"   type="text/html"  )'),
+        ).toBe(
+            `<p><a href="index.txt" download="index.html" type="text/html" class="yfm-file">${iconHtml}index.html</a></p>\n`,
+        );
+    });
+
+    it('should render file without spaces around attrs', () => {
+        expect(transformYfm('%file(src="index.txt"name="index.html"type="text/html")')).toBe(
+            `<p><a href="index.txt" download="index.html" type="text/html" class="yfm-file">${iconHtml}index.html</a></p>\n`,
+        );
+    });
+});


### PR DESCRIPTION
Added plugin for inline file object view. Markup `{% file src="path/to/file" name='readme.md' %}` will rendered to 
<img width="150" alt="image" src="https://user-images.githubusercontent.com/26671342/174584332-7037cdf7-54e5-4798-b121-3e4a3e85775f.png">

```html
<a href="path/to/file" download="readme.md" class="yfm-file"><span class="yfm-file__icon"></span>readme.md</a>
```