### PR TITLE
feat: disable new markdownlint rules

### DIFF
--- a/src/transform/yfmlint/yfmlint.ts
+++ b/src/transform/yfmlint/yfmlint.ts
@@ -50,6 +50,8 @@ const index: LintConfig = {
         MD046: LogLevels.DISABLED, // Code block style
         MD047: LogLevels.DISABLED, // Files should end with a single newline character
         MD048: LogLevels.DISABLED, // Code fence style
+        MD049: LogLevels.DISABLED, // Emphasis style should be consistent
+        MD050: LogLevels.DISABLED, // Strong style should be consistent
 
         YFM001: LogLevels.WARN, // Inline code length
         YFM002: LogLevels.WARN, // No header found in the file for the link text


### PR DESCRIPTION
New rules from markdownlint should be disabled as they conflict with yfm syntax

markdownlint has been updated in this commit: https://github.com/yandex-cloud/yfm-transform/commit/e597abb62a8e74774fd27ffa435f4b86f2f3012d

When I use substitutions `{{my-variable}}`, I get this warning about :
```
MD050/strong-style Strong style should be consistent [Expected: underscore; Actual: asterisk]
```
