### PR TITLE
Revert "DOCSTOOLS-795: remove single-page logic from transform"

### DIFF
--- a/src/transform/plugins/anchors/collect.ts
+++ b/src/transform/plugins/anchors/collect.ts
@@ -1,0 +1,101 @@
+import _ from 'lodash';
+import {sep} from 'path';
+
+import {getSinglePageAnchorId, resolveRelativePath} from '../../utilsFS';
+import {transformLinkToOriginalArticle} from '../../utils';
+import {CUSTOM_ID_REGEXP, CUSTOM_ID_EXCEPTION} from './constants';
+import {сarriage} from '../utils';
+import {MarkdownItPluginOpts} from '../typings';
+
+const slugify: (str: string, opts: {}) => string = require('slugify');
+
+/* eslint-disable max-len */
+/* If the singlePage option is passed in the options:
+ *  - replace the default anchor and custom anchors with anchors with file at the beginning
+ *  - increase the level of headers,
+ *  - add page anchor to the first matched header
+ *  Example for file index.md:
+ *    Before: # Title {#CustomAnchor} {#custom-anchor}
+ *            ## Subtitle
+ *    After: ## Title {data-original-article=/index} {#_index} {#_index_title} {#_index_CustomAnchor} {#_index_custom-anchor}
+ *           ## Subtitle {#_index_subtitle}
+ * */
+const collect = (input: string, options: MarkdownItPluginOpts & {singlePage: boolean}) => {
+    const {root, path, singlePage} = options;
+
+    if (!singlePage || path.includes(`_includes${sep}`)) {
+        return;
+    }
+
+    const currentPath = resolveRelativePath(root, path);
+    const pageId = getSinglePageAnchorId({root, currentPath});
+    let needToSetPageId = true;
+    let needToSetOriginalPathAttr = true;
+    const lines = input.split(сarriage);
+    let i = 0;
+    const HEADER_LINK_REGEXP = /^(?<headerLevel>#+)\s(?<headerContent>.+)$/i;
+
+    while (i < lines.length) {
+        const line = lines[i];
+        const headerMatch = line.match(HEADER_LINK_REGEXP);
+
+        if (!headerMatch) {
+            i++;
+            continue;
+        }
+
+        const {headerLevel, headerContent} = headerMatch.groups as {
+            headerLevel: string;
+            headerContent: string;
+        };
+
+        let newHeaderContent = headerContent;
+        const newCustomHeaders = [];
+
+        while (CUSTOM_ID_REGEXP.test(newHeaderContent)) {
+            newHeaderContent = newHeaderContent.replace(CUSTOM_ID_REGEXP, (match, customId) => {
+                if (match === CUSTOM_ID_EXCEPTION) {
+                    return match;
+                }
+
+                newCustomHeaders.push(`${pageId}_${customId}`);
+                return '';
+            });
+        }
+        newHeaderContent = newHeaderContent.trim();
+
+        const slugifiedTitle = slugify(newHeaderContent, {lower: true});
+        newCustomHeaders.push(`${pageId}_${slugifiedTitle}`);
+        if (needToSetPageId) {
+            newCustomHeaders.push(pageId);
+            needToSetPageId = false;
+        }
+
+        const newCustomHeadersStr = _.chain(newCustomHeaders)
+            .uniq()
+            .map((id) => {
+                return `{${id}}`;
+            })
+            .value()
+            .join(' ');
+
+        const baseHeaderSyntax = `${headerLevel}# ${newHeaderContent}`;
+        lines[i] = `${baseHeaderSyntax} ${newCustomHeadersStr}`;
+
+        if (needToSetOriginalPathAttr) {
+            const originalArticleHref = transformLinkToOriginalArticle({root, currentPath});
+            lines[
+                i
+            ] = `${baseHeaderSyntax} {data-original-article=${originalArticleHref}} ${newCustomHeadersStr}`;
+
+            needToSetOriginalPathAttr = false;
+        }
+
+        i++;
+    }
+
+    // eslint-disable-next-line consistent-return
+    return lines.join(сarriage);
+};
+
+export = collect;

--- a/src/transform/plugins/images/collect.ts
+++ b/src/transform/plugins/images/collect.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from 'markdown-it';
+import {relative} from 'path';
 
 import {isLocalUrl} from '../../utils';
 import {resolveRelativePath} from '../../utilsFS';
@@ -8,13 +9,15 @@ import {MarkdownItPluginOpts} from '../typings';
 type Options = MarkdownItPluginOpts & {
     destPath: string;
     copyFile: (path: string, dest: string) => void;
+    singlePage: boolean;
 };
 
 const collect = (input: string, options: Options) => {
     const md = new MarkdownIt().use(imsize);
 
-    const {path, destPath = '', copyFile} = options;
+    const {root, path, destPath = '', copyFile, singlePage} = options;
     const tokens = md.parse(input, {});
+    let result = input;
 
     tokens.forEach((token) => {
         if (token.type !== 'inline') {
@@ -37,9 +40,19 @@ const collect = (input: string, options: Options) => {
             const targetPath = resolveRelativePath(path, src);
             const targetDestPath = resolveRelativePath(destPath, src);
 
+            if (singlePage && !path.includes('_includes/')) {
+                const newSrc = relative(root, resolveRelativePath(path, src));
+
+                result = result.replace(src, newSrc);
+            }
+
             copyFile(targetPath, targetDestPath);
         });
     });
+
+    if (singlePage) {
+        return result;
+    }
 
     return null;
 };

--- a/src/transform/plugins/links/collect.ts
+++ b/src/transform/plugins/links/collect.ts
@@ -1,0 +1,92 @@
+import MarkdownIt from 'markdown-it';
+import {sep} from 'path';
+import url from 'url';
+import {getHrefTokenAttr, isLocalUrl} from '../../utils';
+import {getSinglePageAnchorId, resolveRelativePath} from '../../utilsFS';
+import index from './index';
+import {PAGE_LINK_REGEXP} from './constants';
+
+const replaceLinkHref = (input: string, href: string, newHref: string) => {
+    /* Try not replace include syntax */
+    return input.replace(`](${href})`, `](${newHref})`);
+};
+
+type Options = {
+    root: string;
+    path: string;
+    singlePage: boolean;
+};
+
+/* Replace the links to the markdown and yaml files if the singlePage option is passed in the options
+ *  Example: replace [Text](../../path/to/file.md#anchor) with [Text](#_path_to_file_anchor)
+ * */
+const collect = (input: string, options: Options) => {
+    const {root, path: startPath, singlePage} = options;
+
+    if (!singlePage) {
+        return;
+    }
+
+    let result = input;
+
+    /* Syntax "{% include [Text](_includes/file.md) %}" is parsed as link. Need to ignore errors */
+    const needSkipLinkFn = (href: string) => href.includes(`_includes${sep}`);
+    const transformLink = (href: string) => href;
+    const md = new MarkdownIt().use(index, {...options, transformLink, needSkipLinkFn});
+    const tokens = md.parse(result, {});
+
+    let i = 0;
+    while (i < tokens.length) {
+        if (tokens[i].type === 'inline') {
+            const childrenTokens = tokens[i].children || [];
+            let j = 0;
+
+            while (j < childrenTokens.length) {
+                const isLinkOpenToken = childrenTokens[j].type === 'link_open';
+
+                if (!isLinkOpenToken) {
+                    j++;
+                    continue;
+                }
+
+                const linkToken = childrenTokens[j];
+                const href = getHrefTokenAttr(linkToken);
+
+                const isIncludeLink = resolveRelativePath(startPath, href).includes(
+                    `_includes${sep}`,
+                );
+
+                if (!href || !isLocalUrl(href) || isIncludeLink) {
+                    j++;
+                    continue;
+                }
+
+                const {pathname, hash} = url.parse(href);
+                if (pathname) {
+                    const isPageFile = PAGE_LINK_REGEXP.test(pathname);
+                    if (isPageFile) {
+                        const newHref = getSinglePageAnchorId({
+                            root,
+                            currentPath: startPath,
+                            pathname,
+                            hash,
+                        });
+                        result = replaceLinkHref(result, href, newHref);
+                    }
+                } else if (hash) {
+                    const newHref = getSinglePageAnchorId({root, currentPath: startPath, hash});
+                    result = replaceLinkHref(result, href, newHref);
+                }
+
+                j++;
+            }
+        }
+
+        i++;
+    }
+
+    // eslint-disable-next-line consistent-return
+    return result;
+};
+
+export = collect;

--- a/src/transform/utils.ts
+++ b/src/transform/utils.ts
@@ -75,6 +75,12 @@ export function isExternalHref(href: string) {
     return href.startsWith('http') || href.startsWith('//');
 }
 
+export function transformLinkToOriginalArticle(opts: {root: string; currentPath: string}) {
+    const {root, currentPath} = opts;
+
+    return currentPath.replace(root, '').replace(/\.(md|ya?ml|html)$/i, '');
+}
+
 export function getHrefTokenAttr(token: Token) {
     let href = token.attrGet('href') || '';
     try {

--- a/src/transform/utilsFS.ts
+++ b/src/transform/utilsFS.ts
@@ -96,3 +96,28 @@ export const getFullIncludePath = (includePath: string, root: string, path: stri
 
     return fullIncludePath;
 };
+
+export function getSinglePageAnchorId(args: {
+    root: string;
+    currentPath: string;
+    pathname?: string;
+    hash?: string | null;
+}) {
+    const {root, currentPath, pathname, hash} = args;
+    let resultAnchor = currentPath;
+
+    if (pathname) {
+        resultAnchor = resolveRelativePath(currentPath, pathname);
+    }
+
+    resultAnchor = resultAnchor
+        .replace(root, '')
+        .replace(/\.(md|ya?ml|html)$/i, '')
+        .replace(new RegExp(_.escapeRegExp(sep), 'gi'), '_');
+
+    if (hash) {
+        resultAnchor = resultAnchor + '_' + hash.slice(1);
+    }
+
+    return `#${resultAnchor}`;
+}


### PR DESCRIPTION
This reverts commit 93c7ae096320018c1c31048b9dadf89f19c5f13e.