### PR TITLE
Add title search inside event path

### DIFF
--- a/src/js/cut.ts
+++ b/src/js/cut.ts
@@ -11,17 +11,47 @@ const ClassName = {
 };
 
 function toggleCut(element: HTMLElement) {
-    const cutEl = element.parentNode as HTMLElement;
-    cutEl.classList.toggle(ClassName.OPEN);
+    const cutNode = element.parentNode;
+
+    if (!(cutNode instanceof HTMLElement)) {
+        return;
+    }
+
+    cutNode.classList.toggle(ClassName.OPEN);
+}
+
+function matchTitle(target: EventTarget | null) {
+    if (!(target instanceof HTMLElement)) {
+        return false;
+    }
+
+    return target?.matches?.(Selector.TITLE);
+}
+
+function findTitleInPath(event: MouseEvent): HTMLElement | undefined {
+    const target = getEventTarget(event);
+
+    if (matchTitle(target)) {
+        return target as HTMLElement;
+    }
+
+    const path = event.composedPath?.();
+
+    return path?.find(matchTitle) as HTMLElement | undefined;
 }
 
 if (typeof document !== 'undefined') {
     document.addEventListener('click', (event) => {
-        const target = getEventTarget(event) as HTMLElement;
-        if (isCustom(event) || !target.matches(Selector.TITLE)) {
+        if (isCustom(event)) {
             return;
         }
 
-        toggleCut(target);
+        const title = findTitleInPath(event);
+
+        if (!title) {
+            return;
+        }
+
+        toggleCut(title);
     });
 }


### PR DESCRIPTION
After adding formatting to the headers of the cuts, clicks on the formatted headers not working.
Added search along the entire path of the event, not just in the target.