### PR TITLE
fix: include src folder for sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "main": "lib/index.js",
   "files": [
     "dist",
-    "lib"
+    "lib",
+    "src"
   ],
   "scripts": {
     "build": "npm run build:css && npm run build:js",


### PR DESCRIPTION
There is a problem that sourcemaps point to files in src folder which is not included when package is published.
Added src folder to files field of package.json