### PR TITLE
fix(include): passing conditionsInCode through pluginOptions

### DIFF
--- a/src/transform/index.ts
+++ b/src/transform/index.ts
@@ -101,6 +101,7 @@ function transform(originInput: string, opts: OptionsType = {}): OutputType {
 
     const pluginOptions = {
         ...customOptions,
+        conditionsInCode,
         vars,
         path,
         extractTitle: extractTitleOption,


### PR DESCRIPTION
Based on: https://github.com/yandex-cloud/yfm-transform/pull/190

in the pr we add conditionsInCode like a prop in include plugin, write test for it, but we didn't account for throwing this prop through transform function, that it is the main case of using the plugin