### PR TITLE
fix: fix inline markup parsing in checkbox label and cut title

### DIFF
--- a/src/transform/plugins/checkbox/checkbox.ts
+++ b/src/transform/plugins/checkbox/checkbox.ts
@@ -27,7 +27,7 @@ export const checkboxReplace = function (_md: MarkdownIt, opts: CheckboxOptions)
     const options = Object.assign(defaults, opts);
 
     const createTokens = function (state: StateCore, checked: boolean, label: string) {
-        let token;
+        let token: Token;
         const nodes = [];
 
         /**
@@ -65,10 +65,7 @@ export const checkboxReplace = function (_md: MarkdownIt, opts: CheckboxOptions)
         /**
          * content of label tag
          */
-        token = new state.Token('inline', '', 0);
-        token.children = [];
-        token.content = label;
-        state.md.inline.parse(token.content, state.md, state.env, token.children);
+        token = state.md.parseInline(label, state.env)[0];
         nodes.push(token);
 
         /**

--- a/src/transform/plugins/cut.ts
+++ b/src/transform/plugins/cut.ts
@@ -45,15 +45,10 @@ const cut: MarkdownItPluginCb = (md, {path, log}) => {
                 const titleOpen = new state.Token('yfm_cut_title_open', 'div', 1);
                 titleOpen.attrSet('class', 'yfm-cut-title');
 
-                const titleInline = new state.Token('inline', '', 0);
-                titleInline.content = match[1] === undefined ? 'ad' : match[1];
-                titleInline.children = [];
-                state.md.inline.parse(
-                    titleInline.content,
-                    state.md,
+                const titleInline = state.md.parseInline(
+                    match[1] === undefined ? 'ad' : match[1],
                     state.env,
-                    titleInline.children,
-                );
+                )[0];
 
                 const titleClose = new state.Token('yfm_cut_title_close', 'div', -1);
 


### PR DESCRIPTION
When using `state.md.inline.parse`, the resulting tokens contain the `text_special` token, which should not be