### PR TITLE
Mark highlight.js as optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,11 @@
   "peerDependencies": {
     "highlight.js": "^10.0.3"
   },
+  "peerDependenciesMeta": {
+    "highlight.js": {
+      "optional": true
+    }
+  },
   "bugs": {
     "url": "https://github.com/yandex-cloud/yfm-transform/issues"
   },


### PR DESCRIPTION
Because it's really optional 
https://github.com/yandex-cloud/yfm-transform/blob/ace2d58021d5d628d8dcba0f7f119f96de5d05c9/src/transform/highlight.ts#L7