### PR TITLE
Add rel=nofollow for anchor links

### DIFF
--- a/src/transform/plugins/anchors/index.ts
+++ b/src/transform/plugins/anchors/index.ts
@@ -20,6 +20,7 @@ function createLinkTokens(state: StateCore, id: string, setId = false) {
     open.attrSet('href', '#' + id);
     open.attrSet('class', 'yfm-anchor');
     open.attrSet('aria-hidden', 'true');
+    open.attrSet('rel', 'nofollow');
     text.content = '';
 
     return [open, text, close];

--- a/test/anchors.test.ts
+++ b/test/anchors.test.ts
@@ -24,7 +24,7 @@ describe('Anchors', () => {
 
     it('should add single anchor', () => {
         expect(transformYfm('## Test {#test1}\n' + '\n' + 'Content\n')).toBe(
-            '<h2 id="test1"><a href="#test1" class="yfm-anchor" aria-hidden="true"></a>Test</h2>\n' +
+            '<h2 id="test1"><a href="#test1" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Test</h2>\n' +
                 '<p>Content</p>\n',
         );
     });
@@ -32,9 +32,9 @@ describe('Anchors', () => {
     it('should add multiple anchors', () => {
         expect(transformYfm('## Test {#test1} {#test2} {#test3}\n' + '\n' + 'Content\n')).toBe(
             '<h2 id="test1">' +
-                '<a id="test3" href="#test3" class="yfm-anchor" aria-hidden="true"></a>' +
-                '<a id="test2" href="#test2" class="yfm-anchor" aria-hidden="true"></a>' +
-                '<a href="#test1" class="yfm-anchor" aria-hidden="true"></a>Test</h2>\n' +
+                '<a id="test3" href="#test3" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>' +
+                '<a id="test2" href="#test2" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>' +
+                '<a href="#test1" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Test</h2>\n' +
                 '<p>Content</p>\n',
         );
     });
@@ -49,9 +49,9 @@ describe('Anchors', () => {
                     '{% include [test](./mocks/include-anchor.md) %}\n',
             ),
         ).toBe(
-            '<h2 id="test0"><a href="#test0" class="yfm-anchor" aria-hidden="true"></a>Test</h2>\n' +
+            '<h2 id="test0"><a href="#test0" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Test</h2>\n' +
                 '<p>Content before include</p>\n' +
-                '<h1 id="test1"><a href="#test1" class="yfm-anchor" aria-hidden="true"></a>Title</h1>\n' +
+                '<h1 id="test1"><a href="#test1" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Title</h1>\n' +
                 '<p>Content</p>\n',
         );
     });
@@ -66,12 +66,12 @@ describe('Anchors', () => {
                     '{% include [test](./mocks/include-multiple-anchors.md) %}\n',
             ),
         ).toBe(
-            '<h2 id="test0"><a href="#test0" class="yfm-anchor" aria-hidden="true"></a>Test</h2>\n' +
+            '<h2 id="test0"><a href="#test0" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Test</h2>\n' +
                 '<p>Content before include</p>\n' +
                 '<h1 id="test1">' +
-                '<a id="test3" href="#test3" class="yfm-anchor" aria-hidden="true"></a>' +
-                '<a id="test2" href="#test2" class="yfm-anchor" aria-hidden="true"></a>' +
-                '<a href="#test1" class="yfm-anchor" aria-hidden="true"></a>Title</h1>\n' +
+                '<a id="test3" href="#test3" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>' +
+                '<a id="test2" href="#test2" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>' +
+                '<a href="#test1" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Title</h1>\n' +
                 '<p>Content</p>\n',
         );
     });
@@ -79,7 +79,7 @@ describe('Anchors', () => {
     it('should be transliterated correctly', () => {
         expect(transformYfm('## Максимальный размер дисков \n' + '\n' + 'Content\n')).toBe(
             '<h2 id="maksimalnyj-razmer-diskov">' +
-                '<a href="#maksimalnyj-razmer-diskov" class="yfm-anchor" aria-hidden="true"></a>' +
+                '<a href="#maksimalnyj-razmer-diskov" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>' +
                 'Максимальный размер дисков' +
                 '</h2>\n' +
                 '<p>Content</p>\n',
@@ -89,7 +89,7 @@ describe('Anchors', () => {
     it('should be removed fences after transliteration', () => {
         expect(transformYfm('## `Test`\n' + '\n' + 'Content\n')).toBe(
             '<h2 id="test">' +
-                '<a href="#test" class="yfm-anchor" aria-hidden="true"></a><code>Test</code>' +
+                '<a href="#test" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a><code>Test</code>' +
                 '</h2>\n' +
                 '<p>Content</p>\n',
         );
@@ -106,7 +106,7 @@ describe('Anchors', () => {
             ),
         ).toBe(
             '<p>Content before include</p>\n' +
-                '<h2 id="anchor"><a href="#anchor" class="yfm-anchor" aria-hidden="true"></a>Subtitle</h2>\n' +
+                '<h2 id="anchor"><a href="#anchor" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Subtitle</h2>\n' +
                 '<p>Subcontent</p>\n' +
                 '<p>After include</p>\n',
         );


### PR DESCRIPTION
![image](https://github.com/yandex-cloud/yfm-transform/assets/48478/1d81f931-6463-4136-b22e-9680d1d4aea2)

У всех подобных якорей нет внятного текста, поэтому поисковики не понимают, как такие ссылки обрабатывать, и кидают SEO-ошибки в SEO-отчеты. Кажется, такие ссылки нужно исключить из индексации.