### PR TITLE
feat(anchors): Revert rel=nofollow and add invisible title for anchors

### DIFF
--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -341,6 +341,31 @@
         line-height: 0;
     }
 
+    /*
+        Hides element visually, but leaves it visible for search crawlers and screen readers
+
+        https://www.a11yproject.com/posts/2013-01-11-how-to-hide-content/
+        https://hugogiraudel.com/2016/10/13/css-hide-and-seek/
+    */
+    .visually-hidden {
+        position: absolute;
+
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+
+        width: 1px;
+        height: 1px;
+        margin: -1px;
+
+        padding: 0;
+
+        white-space: nowrap;
+
+        border: 0;
+
+        clip-path: inset(100%);
+    }
+
     // highlight.js colors
     --yfm-color-hljs-background: #{$codeBackgroundColor};
     --yfm-color-hljs-subst: #444;

--- a/test/anchors.test.ts
+++ b/test/anchors.test.ts
@@ -22,9 +22,16 @@ describe('Anchors', () => {
         log.clear();
     });
 
+    it('should add single anchor with auto naming', () => {
+        expect(transformYfm('## Test\n' + '\n' + 'Content\n')).toBe(
+            '<h2 id="test"><a href="#test" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Test</span></a>Test</h2>\n' +
+                '<p>Content</p>\n',
+        );
+    });
+
     it('should add single anchor', () => {
         expect(transformYfm('## Test {#test1}\n' + '\n' + 'Content\n')).toBe(
-            '<h2 id="test1"><a href="#test1" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Test</h2>\n' +
+            '<h2 id="test1"><a href="#test1" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Test</span></a>Test</h2>\n' +
                 '<p>Content</p>\n',
         );
     });
@@ -32,9 +39,9 @@ describe('Anchors', () => {
     it('should add multiple anchors', () => {
         expect(transformYfm('## Test {#test1} {#test2} {#test3}\n' + '\n' + 'Content\n')).toBe(
             '<h2 id="test1">' +
-                '<a id="test3" href="#test3" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>' +
-                '<a id="test2" href="#test2" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>' +
-                '<a href="#test1" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Test</h2>\n' +
+                '<a id="test3" href="#test3" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Test</span></a>' +
+                '<a id="test2" href="#test2" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Test</span></a>' +
+                '<a href="#test1" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Test</span></a>Test</h2>\n' +
                 '<p>Content</p>\n',
         );
     });
@@ -49,9 +56,9 @@ describe('Anchors', () => {
                     '{% include [test](./mocks/include-anchor.md) %}\n',
             ),
         ).toBe(
-            '<h2 id="test0"><a href="#test0" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Test</h2>\n' +
+            '<h2 id="test0"><a href="#test0" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Test</span></a>Test</h2>\n' +
                 '<p>Content before include</p>\n' +
-                '<h1 id="test1"><a href="#test1" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Title</h1>\n' +
+                '<h1 id="test1"><a href="#test1" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Title</span></a>Title</h1>\n' +
                 '<p>Content</p>\n',
         );
     });
@@ -66,12 +73,12 @@ describe('Anchors', () => {
                     '{% include [test](./mocks/include-multiple-anchors.md) %}\n',
             ),
         ).toBe(
-            '<h2 id="test0"><a href="#test0" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Test</h2>\n' +
+            '<h2 id="test0"><a href="#test0" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Test</span></a>Test</h2>\n' +
                 '<p>Content before include</p>\n' +
                 '<h1 id="test1">' +
-                '<a id="test3" href="#test3" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>' +
-                '<a id="test2" href="#test2" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>' +
-                '<a href="#test1" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Title</h1>\n' +
+                '<a id="test3" href="#test3" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Title</span></a>' +
+                '<a id="test2" href="#test2" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Title</span></a>' +
+                '<a href="#test1" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Title</span></a>Title</h1>\n' +
                 '<p>Content</p>\n',
         );
     });
@@ -79,7 +86,7 @@ describe('Anchors', () => {
     it('should be transliterated correctly', () => {
         expect(transformYfm('## Максимальный размер дисков \n' + '\n' + 'Content\n')).toBe(
             '<h2 id="maksimalnyj-razmer-diskov">' +
-                '<a href="#maksimalnyj-razmer-diskov" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>' +
+                '<a href="#maksimalnyj-razmer-diskov" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Максимальный размер дисков</span></a>' +
                 'Максимальный размер дисков' +
                 '</h2>\n' +
                 '<p>Content</p>\n',
@@ -89,7 +96,7 @@ describe('Anchors', () => {
     it('should be removed fences after transliteration', () => {
         expect(transformYfm('## `Test`\n' + '\n' + 'Content\n')).toBe(
             '<h2 id="test">' +
-                '<a href="#test" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a><code>Test</code>' +
+                '<a href="#test" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Test</span></a><code>Test</code>' +
                 '</h2>\n' +
                 '<p>Content</p>\n',
         );
@@ -106,7 +113,7 @@ describe('Anchors', () => {
             ),
         ).toBe(
             '<p>Content before include</p>\n' +
-                '<h2 id="anchor"><a href="#anchor" class="yfm-anchor" aria-hidden="true" rel="nofollow"></a>Subtitle</h2>\n' +
+                '<h2 id="anchor"><a href="#anchor" class="yfm-anchor" aria-hidden="true"><span class="visually-hidden">Subtitle</span></a>Subtitle</h2>\n' +
                 '<p>Subcontent</p>\n' +
                 '<p>After include</p>\n',
         );


### PR DESCRIPTION
В этом PR речь про якорные ссылки, которые есть возле каждого заголовка (`H1`, `H2`...). В этих ссылках вообще нет текстового контента, а при наведении на якорь показывается кликабельный символ `#`.


1. Откатываю назад `rel=nofollow` для таких якорей
- в прошлом PR я предложил ерунду, виноват. Этот атрибут не помог — парсеры сайтов всё равно продолжают анализировать смысл таких ссылок. Но оно и логично.  С точки зрения семантики правило же простое: "Любая ссылка должна иметь текст, иначе в ней нет смысла для пользователя."
- вдобавок, оказалось, что ссылки с `rel=follow` поисковые краулеры советуют не использоать:  `is not recommended that you use nofollow attributes in internal links. You should let link juice flow freely throughout your website. Moreover, unintentional use of nofollow attributes may result in your webpage being ignored by search engine crawlers even if it contains a valuable content.` Особенно пугает  последнее предложение.

2. Предлагаю правильный фикс.
- в якорной ссылке размещаем span с тем же текстом, что и в заголовке, к которому этот якорь принадлежит (финальная верстка см. в файл с тестами)
- на этот span навешиваем CSS-класc, который прячет блок от зрячих пользователей, но оставляет доступным для краулеров и скринридеров.

Таким способом мы однозначно улучшаем доступность заголовков, улучшаем SEO-индексируемость