### PR TITLE
fix(anchors): Styles for heading's anchor in table

### DIFF
--- a/src/scss/_anchor.scss
+++ b/src/scss/_anchor.scss
@@ -20,4 +20,14 @@
             visibility: visible;
         }
     }
+
+    table {
+        h1, h2, h3, h4, h5, h6 {
+            .yfm-anchor {
+                width: 1em;
+                margin-left: -1em;
+                padding-right: 0;
+            }
+        }
+    };
 }


### PR DESCRIPTION
Когда в таблицу вставлен заголовок, инструмент автоматически создаёт якорь. 

Баг в том, что внутри таблицы этот якорь обрезается по левому краю
![image](https://github.com/yandex-cloud/yfm-transform/assets/48478/149d9f9f-96dc-4e51-a976-fbc561aad586)

Для якорей внутри таблицы переопределяю стили так, чтобы якорь не обрезался
![image](https://github.com/yandex-cloud/yfm-transform/assets/48478/2c45bf5c-2cc9-454b-b0db-7541c50f8f29)