### PR TITLE
fix: absolute links in included files

### DIFF
--- a/src/transform/plugins/links/index.ts
+++ b/src/transform/plugins/links/index.ts
@@ -6,7 +6,7 @@ import {PAGE_LINK_REGEXP} from './constants';
 import Token from 'markdown-it/lib/token';
 import {Logger} from 'src/transform/log';
 import {MarkdownItPluginCb, MarkdownItPluginOpts} from '../typings';
-import path, {parse, relative, resolve} from 'path';
+import path, {isAbsolute, parse, relative, resolve} from 'path';
 import {StateCore} from 'src/transform/typings';
 
 function defaultTransformLink(href: string) {
@@ -110,6 +110,10 @@ function processLink(state: StateCore, tokens: Token[], idx: number, opts: ProcO
     if (!isLocalUrl(href)) {
         linkToken.attrSet('target', '_blank');
         linkToken.attrSet('rel', 'noreferrer noopener');
+        return;
+    }
+
+    if (isAbsolute(href)) {
         return;
     }
 

--- a/test/links.test.ts
+++ b/test/links.test.ts
@@ -77,4 +77,20 @@ describe('Links', () => {
 
         expect(result).toEqual('<h1>First</h1>\n<p><a href="./second.html">Second</a></p>\n');
     });
+
+    test('Should create link with the absolute path', () => {
+        const inputPath = resolve(__dirname, './mocks/absolute-link.md');
+        const input = readFileSync(inputPath, 'utf8');
+        const result = transformYfm(input, inputPath);
+
+        expect(result).toEqual('<p><a href="/link/">Absolute link</a></p>\n');
+    });
+
+    test('Should create link with the absolute path from the included file', () => {
+        const result = transformYfm(
+            ['', '{% include [create-folder](./mocks/absolute-link.md) %}', ''].join('\n'),
+        );
+
+        expect(result).toEqual('<p><a href="/link/">Absolute link</a></p>\n');
+    });
 });

--- a/test/mocks/absolute-link.md
+++ b/test/mocks/absolute-link.md
@@ -1,0 +1,1 @@
+[Absolute link](/link/)


### PR DESCRIPTION
I found a strange bug that sometimes absolute links are replaced by random local paths only in included files.

The relative file:
![photo_2023-09-04 12 10 13](https://github.com/yandex-cloud/yfm-transform/assets/4435642/59ced418-be4c-4dfd-aa7b-603fb1e2333a)

The included file:
![photo_2023-09-04 12 10 14](https://github.com/yandex-cloud/yfm-transform/assets/4435642/77ba924a-c0fa-4ad9-971a-3012f9a69a6c)

The result:
![photo_2023-09-04 12 10 07](https://github.com/yandex-cloud/yfm-transform/assets/4435642/40e601cf-3441-4b16-88d9-7ac1cf72e4bc)

Absolute links, not from included files, work as expected.