### PR TITLE
Fixed squashing consequtive spaces in inlined code.

### DIFF
--- a/src/scss/_common.scss
+++ b/src/scss/_common.scss
@@ -324,7 +324,7 @@
         background-color: $inlineCodeBackgroundColor;
         border-radius: 4px;
         font-size: 0.875em;
-        white-space: normal;
+        white-space: pre-wrap;
         color: $inlineCodeColor;
     }
 


### PR DESCRIPTION
This fix addresses the issue https://github.com/diplodoc-platform/transform/issues/455