### PR TITLE
fix: remove xml header from svg

### DIFF
--- a/src/transform/plugins/images/index.ts
+++ b/src/transform/plugins/images/index.ts
@@ -186,6 +186,9 @@ function replaceSvgContent(content: string | null, options: ImageOptions) {
     // monoline
     content = content.replace(/>\r?\n</g, '><').replace(/\r?\n/g, ' ');
 
+    // remove <?xml...?>
+    content = content.replace(/<\?xml.*?\?>.*?(<svg.*)/g, '$1');
+
     // width, height
     let svgRoot = content.replace(/.*?<svg([^>]*)>.*/g, '$1');
 


### PR DESCRIPTION
If the svg image contains <?xml...?>, then when embedding it in the md2md phase, the link that goes in the same line will not be found later by the md-it parser.

`![](image_src)[This link not found](link)`