### PR TITLE
fix: svg with incorrect parse by md-it from linux

### DIFF
--- a/src/transform/plugins/imsize/plugin.ts
+++ b/src/transform/plugins/imsize/plugin.ts
@@ -202,7 +202,7 @@ export const imageWithSize = (md: MarkdownIt, opts?: ImsizeOptions): ParserInlin
             // Handle inline attribute from curly braces
             if (state.src.slice(Math.max(0, pos), max).includes('{')) {
                 const result = parseInlineAttributes(
-                    state.src.slice(Math.max(0, pos) + 1, max - 1),
+                    state.src.slice(Math.max(0, pos) + 1, max - 1).replace(/\{?(.*?)\}.*/, '$1'),
                 );
 
                 if (result.width !== '') {


### PR DESCRIPTION
Fix incorrect parse in linux

```Text ![](path_to_svg){inline=false}, other text.```