### PR TITLE
feat(table): implement table attributes syntax

### DIFF
--- a/src/transform/plugins/table/index.ts
+++ b/src/transform/plugins/table/index.ts
@@ -1,6 +1,7 @@
 import type StateBlock from 'markdown-it/lib/rules_block/state_block';
 import type Token from 'markdown-it/lib/token';
 import type {MarkdownItPluginCb} from '../typings';
+import type {Logger} from '../../log';
 import type {TableAttrs, YfmTablePluginOptions} from './types';
 
 import {AttrsParser, parseMdAttrs} from '@diplodoc/utils';
@@ -522,9 +523,10 @@ function extractAttributes(state: StateBlock, pos: number): Record<string, strin
  *
  * @param {Token} contentToken - Search the content of this token for the class.
  * @param {Token} tdOpenToken - Parent td_open token. Extracted class is applied to this token.
+ * @param {Logger} log - Logger instance for deprecation warnings.
  * @returns {void}
  */
-function extractAndApplyClassFromToken(contentToken: Token, tdOpenToken: Token): void {
+function extractAndApplyClassFromToken(contentToken: Token, tdOpenToken: Token, log: Logger): void {
     // Regex to find class attribute in any position within brackets
     const blockRegex = /\s*\{[^}]*}$/;
     const allAttrs = contentToken.content.match(blockRegex);
@@ -536,6 +538,11 @@ function extractAndApplyClassFromToken(contentToken: Token, tdOpenToken: Token):
     const attrsClass = attrs?.class?.join(' ');
 
     if (attrsClass) {
+        if (attrsClass.split(' ').some((c) => c.startsWith('cell-align-'))) {
+            log.warn(
+                `Deprecated: use align="..." inside cell attributes "::{align=\\"...\\"}" instead of .cell-align-* class in cell content "{ }"`,
+            );
+        }
         tdOpenToken.attrSet('class', attrsClass);
         // remove the class from the token so that it's not propagated to tr or table level
         let replacedContent = allAttrs[0].replace(`.${attrsClass}`, '');
@@ -543,6 +550,30 @@ function extractAndApplyClassFromToken(contentToken: Token, tdOpenToken: Token):
             replacedContent = '';
         }
         contentToken.content = contentToken.content.replace(allAttrs[0], replacedContent);
+    }
+}
+
+const VALID_ALIGN_VALUES: ReadonlySet<string> = new Set([
+    'top-left',
+    'top-center',
+    'top-right',
+    'center',
+    'bottom-left',
+    'bottom-right',
+]);
+
+function applyCellAttrs(token: Token, rawAttrs: TableAttrs, log: Logger): void {
+    if ('align' in rawAttrs) {
+        const value = rawAttrs['align'];
+        if (!VALID_ALIGN_VALUES.has(value)) {
+            log.warn(`Unknown table cell align value: "${value}"`);
+        }
+        token.meta = token.meta || {};
+        token.meta.align = value;
+        token.attrSet('data-align', value);
+        if (value) {
+            token.attrJoin('class', `cell-align-${value}`);
+        }
     }
 }
 
@@ -740,6 +771,7 @@ const yfmTable: MarkdownItPluginCb<YfmTablePluginOptions> = (md, opts) => {
                     token.map = [begin.line, end.line];
                     token.meta = token.meta || {};
                     token.meta.rawAttrs = cellRawAttrs;
+                    applyCellAttrs(token, cellRawAttrs, opts.log);
 
                     const oldTshift = state.tShift[begin.line];
                     const oldEMark = state.eMarks[end.line];
@@ -768,7 +800,11 @@ const yfmTable: MarkdownItPluginCb<YfmTablePluginOptions> = (md, opts) => {
                     state.eMarks[end.line] = oldEMark;
 
                     const rowTokens = cellsMap[cellsMap.length - 1];
-                    extractAndApplyClassFromToken(contentToken, rowTokens[rowTokens.length - 1]);
+                    extractAndApplyClassFromToken(
+                        contentToken,
+                        rowTokens[rowTokens.length - 1],
+                        opts.log,
+                    );
                 }
 
                 if (rowLength < maxRowLength) {

--- a/src/transform/plugins/table/index.ts
+++ b/src/transform/plugins/table/index.ts
@@ -226,8 +226,10 @@ class StateIterator {
     }
 }
 
+type RowData = {start: number; end: number; cols: [Stats, Stats][]; rawAttrs: TableAttrs};
+
 interface RowPositions {
-    rows: [number, number, [Stats, Stats][]][];
+    rows: RowData[];
     endOfTable: number | null;
     pos: number;
     tableAttrs: TableAttrs;
@@ -302,12 +304,13 @@ function getTableRowPositions(
     let currentRow: [Stats, Stats][] = [];
     let colStart: Stats | null = null;
     let rowStart: number | null = null;
+    let currentRowAttrs: TableAttrs = {};
 
     const iter = new StateIterator(state, startPosition + openTableOrder.length, startLine);
 
     const tableAttrs = parseTableAttrs(state, iter);
 
-    const rows: [number, number, typeof currentRow][] = [];
+    const rows: RowData[] = [];
 
     let isInsideCode = false;
     let isInsideMath = false;
@@ -319,11 +322,17 @@ function getTableRowPositions(
             currentRow.push([colStart, iter.stats()]);
         }
         if (currentRow.length && rowStart) {
-            rows.push([rowStart, iter.line, currentRow]);
+            rows.push({
+                start: rowStart,
+                end: iter.line,
+                cols: currentRow,
+                rawAttrs: currentRowAttrs,
+            });
         }
         currentRow = [];
         colStart = null;
         rowStart = null;
+        currentRowAttrs = {};
     };
 
     while (iter.pos <= endPosition) {
@@ -416,6 +425,8 @@ function getTableRowPositions(
             } else {
                 iter.next(rowStartOrder.length);
                 rowStart = iter.line;
+
+                currentRowAttrs = parseInlineAttrs(state, iter, 1);
                 colStart = iter.stats();
             }
 
@@ -439,6 +450,26 @@ function getTableRowPositions(
     const {pos} = iter;
 
     return {rows, endOfTable, pos, tableAttrs};
+}
+
+function parseInlineAttrs(state: StateBlock, iter: StateIterator, prefixLen: number): TableAttrs {
+    const result: TableAttrs = {};
+    if (
+        iter.pos > iter.lineEnds ||
+        state.src.charCodeAt(iter.pos) !== colonChar ||
+        state.src.charCodeAt(iter.pos + 1) !== curlyBraceOpen
+    ) {
+        return result;
+    }
+    const parsed = parseMdAttrs(state.md, state.src, iter.pos + prefixLen, iter.lineEnds);
+    if (!parsed) {
+        return result;
+    }
+    for (const [key, values] of Object.entries(parsed.attrs)) {
+        result[key] = values[0];
+    }
+    iter.next(parsed.pos - iter.pos);
+    return result;
 }
 
 function extractAttributes(state: StateBlock, pos: number): Record<string, string[]> {
@@ -641,7 +672,7 @@ const yfmTable: MarkdownItPluginCb<YfmTablePluginOptions> = (md, opts) => {
             token = state.push('yfm_tbody_open', 'tbody', 1);
             token.map = [startLine + 1, endOfTable - 1];
 
-            const maxRowLength = Math.max(...rows.map(([, , cols]) => cols.length));
+            const maxRowLength = Math.max(...rows.map((row) => row.cols.length));
 
             // cellsMaps is a 2-D map of all td_open tokens in the table.
             // cellsMap is used to access the table cells by [row][column] coordinates
@@ -652,13 +683,20 @@ const yfmTable: MarkdownItPluginCb<YfmTablePluginOptions> = (md, opts) => {
             const contentMap: string[][] = [];
 
             for (let i = 0; i < rows.length; i++) {
-                const [rowLineStarts, rowLineEnds, cols] = rows[i];
+                const {
+                    start: rowLineStarts,
+                    end: rowLineEnds,
+                    cols,
+                    rawAttrs: rowRawAttrs,
+                } = rows[i];
                 cellsMap.push([]);
                 contentMap.push([]);
                 const rowLength = cols.length;
 
                 token = state.push('yfm_tr_open', 'tr', 1);
                 token.map = [rowLineStarts, rowLineEnds];
+                token.meta = token.meta || {};
+                token.meta.rawAttrs = rowRawAttrs;
 
                 for (let j = 0; j < cols.length; j++) {
                     const [begin, end] = cols[j];

--- a/src/transform/plugins/table/index.ts
+++ b/src/transform/plugins/table/index.ts
@@ -1,12 +1,13 @@
 import type StateBlock from 'markdown-it/lib/rules_block/state_block';
 import type Token from 'markdown-it/lib/token';
 import type {MarkdownItPluginCb} from '../typings';
-import type {YfmTablePluginOptions} from './types';
+import type {TableAttrs, YfmTablePluginOptions} from './types';
 
-import {AttrsParser} from '@diplodoc/utils';
+import {AttrsParser, parseMdAttrs} from '@diplodoc/utils';
 
 const pluginName = 'yfm_table';
 const pipeChar = 0x7c; // |
+const colonChar = 0x3a; // :
 const apostropheChar = 0x60; // `
 const hashChar = 0x23; // #
 const backSlashChar = 0x5c; // \
@@ -229,6 +230,63 @@ interface RowPositions {
     rows: [number, number, [Stats, Stats][]][];
     endOfTable: number | null;
     pos: number;
+    tableAttrs: TableAttrs;
+}
+
+/**
+ * Parses table options from lines between #| and the first || or |#.
+ *
+ * Option line format: `|:{key="value" key2="value2"}`
+ * Multiple option lines are supported; results are merged.
+ */
+function parseTableAttrs(state: StateBlock, iter: StateIterator): TableAttrs {
+    const options: TableAttrs = {};
+    const {src} = state;
+    const utils = state.md.utils;
+
+    let parsing = true;
+
+    while (parsing) {
+        const lineEnd = iter.lineEnds;
+
+        // Skip leading whitespace to find first non-space char
+        let first = iter.pos;
+        while (first < lineEnd && utils.isSpace(src.charCodeAt(first))) {
+            first++;
+        }
+
+        // Skip empty lines
+        if (first >= lineEnd) {
+            iter.next(lineEnd - iter.pos + 1);
+            continue;
+        }
+
+        // Stop if we hit row start || or table close |#
+        if (isRowOrder(src, first) || isCloseTableOrder(src, first)) {
+            parsing = false;
+            continue;
+        }
+
+        // Option line must start with |:
+        if (src.charCodeAt(first) !== pipeChar || src.charCodeAt(first + 1) !== colonChar) {
+            parsing = false;
+            continue;
+        }
+
+        const result = parseMdAttrs(state.md, src, first + 2, lineEnd);
+        if (!result) {
+            parsing = false;
+            continue;
+        }
+
+        for (const [key, values] of Object.entries(result.attrs)) {
+            options[key] = values[values.length - 1];
+        }
+
+        iter.next(lineEnd - iter.pos + 1);
+    }
+
+    return options;
 }
 
 // eslint-disable-next-line complexity
@@ -246,6 +304,8 @@ function getTableRowPositions(
     let rowStart: number | null = null;
 
     const iter = new StateIterator(state, startPosition + openTableOrder.length, startLine);
+
+    const tableAttrs = parseTableAttrs(state, iter);
 
     const rows: [number, number, typeof currentRow][] = [];
 
@@ -378,7 +438,7 @@ function getTableRowPositions(
 
     const {pos} = iter;
 
-    return {rows, endOfTable, pos};
+    return {rows, endOfTable, pos, tableAttrs};
 }
 
 function extractAttributes(state: StateBlock, pos: number): Record<string, string[]> {
@@ -539,7 +599,7 @@ const yfmTable: MarkdownItPluginCb<YfmTablePluginOptions> = (md, opts) => {
                 return true;
             }
 
-            const {rows, endOfTable, pos} = getTableRowPositions(
+            const {rows, endOfTable, pos, tableAttrs} = getTableRowPositions(
                 state,
                 startPosition,
                 endPosition,
@@ -575,6 +635,8 @@ const yfmTable: MarkdownItPluginCb<YfmTablePluginOptions> = (md, opts) => {
             }
 
             token.map = [startLine, endOfTable];
+            token.meta = token.meta || {};
+            token.meta.rawAttrs = tableAttrs;
 
             token = state.push('yfm_tbody_open', 'tbody', 1);
             token.map = [startLine + 1, endOfTable - 1];

--- a/src/transform/plugins/table/index.ts
+++ b/src/transform/plugins/table/index.ts
@@ -226,7 +226,8 @@ class StateIterator {
     }
 }
 
-type RowData = {start: number; end: number; cols: [Stats, Stats][]; rawAttrs: TableAttrs};
+type CellData = {start: Stats; end: Stats; rawAttrs: TableAttrs};
+type RowData = {start: number; end: number; cols: CellData[]; rawAttrs: TableAttrs};
 
 interface RowPositions {
     rows: RowData[];
@@ -301,8 +302,9 @@ function getTableRowPositions(
 ): RowPositions {
     let endOfTable = null;
     let tableLevel = 0;
-    let currentRow: [Stats, Stats][] = [];
+    let currentRow: CellData[] = [];
     let colStart: Stats | null = null;
+    let pendingCellAttrs: TableAttrs = {};
     let rowStart: number | null = null;
     let currentRowAttrs: TableAttrs = {};
 
@@ -319,7 +321,8 @@ function getTableRowPositions(
 
     const addRow = () => {
         if (colStart) {
-            currentRow.push([colStart, iter.stats()]);
+            currentRow.push({start: colStart, end: iter.stats(), rawAttrs: pendingCellAttrs});
+            pendingCellAttrs = {};
         }
         if (currentRow.length && rowStart) {
             rows.push({
@@ -426,7 +429,35 @@ function getTableRowPositions(
                 iter.next(rowStartOrder.length);
                 rowStart = iter.line;
 
-                currentRowAttrs = parseInlineAttrs(state, iter, 1);
+                const hasRowAttrs =
+                    iter.pos <= iter.lineEnds &&
+                    state.src.charCodeAt(iter.pos) === colonChar &&
+                    state.src.charCodeAt(iter.pos + 1) === curlyBraceOpen;
+                if (hasRowAttrs) {
+                    currentRowAttrs = parseInlineAttrs(state, iter, 1);
+                } else {
+                    currentRowAttrs = {};
+                }
+
+                // skip spaces/tabs on same line only if row attrs were present, then check for first-cell attrs ::{...}
+                if (hasRowAttrs) {
+                    while (
+                        iter.pos <= iter.lineEnds &&
+                        state.md.utils.isSpace(state.src.charCodeAt(iter.pos))
+                    ) {
+                        iter.next(1);
+                    }
+                }
+                if (
+                    iter.pos <= iter.lineEnds &&
+                    state.src.charCodeAt(iter.pos) === colonChar &&
+                    state.src.charCodeAt(iter.pos + 1) === colonChar
+                ) {
+                    pendingCellAttrs = parseInlineAttrs(state, iter, 2);
+                } else {
+                    pendingCellAttrs = {};
+                }
+
                 colStart = iter.stats();
             }
 
@@ -437,9 +468,20 @@ function getTableRowPositions(
 
         if (isCellOrder(state.src, iter.pos)) {
             if (colStart) {
-                currentRow.push([colStart, iter.stats()]);
+                currentRow.push({start: colStart, end: iter.stats(), rawAttrs: pendingCellAttrs});
+                pendingCellAttrs = {};
             }
             iter.next(cellStartOrder.length);
+            // check for cell attrs ::{...} immediately after | (no spaces allowed)
+            if (
+                iter.pos <= iter.lineEnds &&
+                state.src.charCodeAt(iter.pos) === colonChar &&
+                state.src.charCodeAt(iter.pos + 1) === colonChar
+            ) {
+                pendingCellAttrs = parseInlineAttrs(state, iter, 2);
+            } else {
+                pendingCellAttrs = {};
+            }
             colStart = iter.stats();
             continue;
         }
@@ -454,13 +496,6 @@ function getTableRowPositions(
 
 function parseInlineAttrs(state: StateBlock, iter: StateIterator, prefixLen: number): TableAttrs {
     const result: TableAttrs = {};
-    if (
-        iter.pos > iter.lineEnds ||
-        state.src.charCodeAt(iter.pos) !== colonChar ||
-        state.src.charCodeAt(iter.pos + 1) !== curlyBraceOpen
-    ) {
-        return result;
-    }
     const parsed = parseMdAttrs(state.md, state.src, iter.pos + prefixLen, iter.lineEnds);
     if (!parsed) {
         return result;
@@ -699,10 +734,12 @@ const yfmTable: MarkdownItPluginCb<YfmTablePluginOptions> = (md, opts) => {
                 token.meta.rawAttrs = rowRawAttrs;
 
                 for (let j = 0; j < cols.length; j++) {
-                    const [begin, end] = cols[j];
+                    const {start: begin, end, rawAttrs: cellRawAttrs} = cols[j];
                     token = state.push('yfm_td_open', 'td', 1);
                     cellsMap[i].push(token);
                     token.map = [begin.line, end.line];
+                    token.meta = token.meta || {};
+                    token.meta.rawAttrs = cellRawAttrs;
 
                     const oldTshift = state.tShift[begin.line];
                     const oldEMark = state.eMarks[end.line];

--- a/src/transform/plugins/table/types.ts
+++ b/src/transform/plugins/table/types.ts
@@ -1,3 +1,5 @@
+export type TableAttrs = Record<string, string>;
+
 export type YfmTablePluginOptions = {
     /**
      * Sets whether to interpret the pipe symbol inside the code block as a table separator.

--- a/test/table/table.test.ts
+++ b/test/table/table.test.ts
@@ -1873,3 +1873,129 @@ describe('row attrs', () => {
         expect(html).toContain('<td>\n<p>A</p>\n</td>');
     });
 });
+
+describe('cell attrs', () => {
+    const parseTokens = (text: string, opts?: YfmTablePluginOptions) => {
+        const md = new MarkdownIt();
+        md.use(table, opts ?? {});
+        return md.parse(text, {});
+    };
+
+    const findTokens = (tokens: ReturnType<typeof parseTokens>, type: string) =>
+        tokens.filter((t: {type: string}) => t.type === type);
+
+    it('|::{key="v"} sets rawAttrs on second yfm_td_open', () => {
+        const tokens = parseTokens('#|\n|| A |::{key="v"} B ||\n|#');
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({});
+        expect(tdOpens[1]?.meta?.rawAttrs).toEqual({key: 'v'});
+    });
+
+    it('||::{key="v"} sets rawAttrs on first yfm_td_open (no row attrs)', () => {
+        const tokens = parseTokens('#|\n||::{key="v"} A | B ||\n|#');
+        const trOpen = findTokens(tokens, 'yfm_tr_open')[0];
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(trOpen?.meta?.rawAttrs).toEqual({});
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({key: 'v'});
+        expect(tdOpens[1]?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('||:{r="1"} ::{c="1"} A sets both row and first-cell attrs', () => {
+        const tokens = parseTokens('#|\n||:{r="1"} ::{c="1"} A | B ||\n|#');
+        const trOpen = findTokens(tokens, 'yfm_tr_open')[0];
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(trOpen?.meta?.rawAttrs).toEqual({r: '1'});
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({c: '1'});
+        expect(tdOpens[1]?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('||:{r="1"}::{c="1"} A — no space between row and cell attrs', () => {
+        const tokens = parseTokens('#|\n||:{r="1"}::{c="1"} A | B ||\n|#');
+        const trOpen = findTokens(tokens, 'yfm_tr_open')[0];
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(trOpen?.meta?.rawAttrs).toEqual({r: '1'});
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({c: '1'});
+    });
+
+    it('||:{r="1"}   \t::{c="1"} A — multiple spaces/tabs between row and cell attrs', () => {
+        const tokens = parseTokens('#|\n||:{r="1"}   \t::{c="1"} A | B ||\n|#');
+        const trOpen = findTokens(tokens, 'yfm_tr_open')[0];
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(trOpen?.meta?.rawAttrs).toEqual({r: '1'});
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({c: '1'});
+    });
+
+    it('|| A |::{} B sets empty rawAttrs on second cell', () => {
+        const tokens = parseTokens('#|\n|| A |::{} B ||\n|#');
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(tdOpens[1]?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('|| A | B — no cell attrs sets empty rawAttrs on all cells', () => {
+        const tokens = parseTokens('#|\n|| A | B ||\n|#');
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({});
+        expect(tdOpens[1]?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('| ::{k="v"} space before ::{ — does not parse as cell attrs for second cell', () => {
+        const tokens = parseTokens('#|\n|| A | ::{k="v"} B ||\n|#');
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(tdOpens[1]?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('|| A |\\n::{k="v"} B — newline before ::{ does not parse as cell attrs', () => {
+        const tokens = parseTokens('#|\n|| A |\n::{k="v"} B ||\n|#');
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(tdOpens[1]?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('||:{r="1"}\\n::{c="1"} — cell attrs on next line not parsed', () => {
+        const tokens = parseTokens('#|\n||:{r="1"}\n::{c="1"} G | H ||\n|#');
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('|::{...} does not leak ::{...} into cell content HTML', () => {
+        const html = transformYfm('#|\n|| A |::{key="v"} B ||\n|#');
+        expect(html).not.toContain('::{');
+        expect(html).not.toContain('key=&quot;v&quot;');
+        expect(html).toContain('<td>\n<p>B</p>\n</td>');
+    });
+
+    it('cell with ::{...} and colspan > works correctly', () => {
+        const html = transformYfm('#|\n||::{k="v"} A | > ||\n|#');
+        expect(html).toContain('colspan="2"');
+        expect(html).not.toContain('::{');
+    });
+
+    it('::{k="v"} on colspan > cell — first cell gets rawAttrs, colspan applied', () => {
+        const tokens = parseTokens('#|\n||::{k="v"} A |::{k2="v2"} > ||\n|#');
+        // clearTokens removes the > cell from output tokens
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({k: 'v'});
+        expect(tdOpens[0]?.attrGet('colspan')).toBe('2');
+        // only 1 td_open survives after clearTokens removes the > cell
+        expect(tdOpens).toHaveLength(1);
+    });
+
+    it('|| ::{k="v"} A — space before ::{ without row attrs does not parse as cell attrs', () => {
+        const tokens = parseTokens('#|\n|| ::{k="v"} A ||\n|#');
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('||:{r="1"} ::{c="1"} A — space before ::{ with row attrs parses correctly', () => {
+        const tokens = parseTokens('#|\n||:{r="1"} ::{c="1"} A ||\n|#');
+        const trOpen = findTokens(tokens, 'yfm_tr_open')[0];
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(trOpen?.meta?.rawAttrs).toEqual({r: '1'});
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({c: '1'});
+    });
+
+    it('||:{} ::{c="1"} A — empty row attrs syntax present, space before ::{ is allowed', () => {
+        const tokens = parseTokens('#|\n||:{} ::{c="1"} A ||\n|#');
+        const tdOpens = findTokens(tokens, 'yfm_td_open');
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({c: '1'});
+    });
+});

--- a/test/table/table.test.ts
+++ b/test/table/table.test.ts
@@ -1818,3 +1818,58 @@ describe('table attrs', () => {
         expect(tableOpen?.meta?.rawAttrs).toEqual({key: 'second'});
     });
 });
+
+describe('row attrs', () => {
+    const parseTokens = (text: string, opts?: YfmTablePluginOptions) => {
+        const md = new MarkdownIt();
+        md.use(table, opts ?? {});
+        return md.parse(text, {});
+    };
+
+    const findTokens = (tokens: ReturnType<typeof parseTokens>, type: string) =>
+        tokens.filter((t: {type: string}) => t.type === type);
+
+    it('||:{key="value"} sets rawAttrs on yfm_tr_open', () => {
+        const tokens = parseTokens('#|\n||:{key="value"} A | B ||\n|#');
+        const trOpen = findTokens(tokens, 'yfm_tr_open')[0];
+        expect(trOpen?.meta?.rawAttrs).toEqual({key: 'value'});
+    });
+
+    it('||:{} sets empty rawAttrs on yfm_tr_open', () => {
+        const tokens = parseTokens('#|\n||:{} A | B ||\n|#');
+        const trOpen = findTokens(tokens, 'yfm_tr_open')[0];
+        expect(trOpen?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('|| without attrs sets empty rawAttrs', () => {
+        const tokens = parseTokens('#|\n|| A | B ||\n|#');
+        const trOpen = findTokens(tokens, 'yfm_tr_open')[0];
+        expect(trOpen?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('multiple rows each get their own rawAttrs', () => {
+        const tokens = parseTokens('#|\n||:{r="1"} A ||\n||:{r="2"} B ||\n|#');
+        const trOpens = findTokens(tokens, 'yfm_tr_open');
+        expect(trOpens[0]?.meta?.rawAttrs).toEqual({r: '1'});
+        expect(trOpens[1]?.meta?.rawAttrs).toEqual({r: '2'});
+    });
+
+    it('|| :{...} with space after || does not parse as row attrs', () => {
+        const tokens = parseTokens('#|\n|| :{key="v"} A | B ||\n|#');
+        const trOpen = findTokens(tokens, 'yfm_tr_open')[0];
+        expect(trOpen?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('||:{...} on next line after || does not parse as row attrs', () => {
+        const tokens = parseTokens('#|\n||\n:{key="v"} A | B ||\n|#');
+        const trOpen = findTokens(tokens, 'yfm_tr_open')[0];
+        expect(trOpen?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('||:{key="v"} does not leak :{...} into cell content HTML', () => {
+        const html = transformYfm('#|\n||:{key="v"} A | B ||\n|#');
+        expect(html).not.toContain(':{');
+        expect(html).not.toContain('key=&quot;v&quot;');
+        expect(html).toContain('<td>\n<p>A</p>\n</td>');
+    });
+});

--- a/test/table/table.test.ts
+++ b/test/table/table.test.ts
@@ -6,6 +6,7 @@ import MarkdownIt from 'markdown-it';
 import transform from '../../src/transform';
 import table from '../../src/transform/plugins/table';
 import includes from '../../src/transform/plugins/includes';
+import {log} from '../../src/transform/log';
 
 const transformYfm = (text: string, opts?: YfmTablePluginOptions) => {
     const {
@@ -1997,5 +1998,87 @@ describe('cell attrs', () => {
         const tokens = parseTokens('#|\n||:{} ::{c="1"} A ||\n|#');
         const tdOpens = findTokens(tokens, 'yfm_td_open');
         expect(tdOpens[0]?.meta?.rawAttrs).toEqual({c: '1'});
+    });
+});
+
+describe('cell align attribute', () => {
+    const parseTokens = (text: string, opts?: YfmTablePluginOptions) => {
+        const md = new MarkdownIt();
+        md.use(table, opts ?? {});
+        return md.parse(text, {});
+    };
+
+    it('align="center" adds cell-align-center class on td', () => {
+        const tokens = parseTokens('#|\n||::{align="center"} A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        expect(tdOpens[0]?.attrGet('class')).toBe('cell-align-center');
+    });
+
+    it('align="top-left" adds cell-align-top-left class on td', () => {
+        const tokens = parseTokens('#|\n||::{align="top-left"} A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        expect(tdOpens[0]?.attrGet('class')).toBe('cell-align-top-left');
+    });
+
+    it('align="unknown-value" adds class on td and emits warn', () => {
+        const {
+            result: {html},
+            logs,
+        } = transform('#|\n||::{align="unknown-value"} A ||\n|#', {
+            plugins: [table],
+            enableMarkdownAttrs: false,
+        });
+        expect(html).toContain('<td data-align="unknown-value" class="cell-align-unknown-value">');
+        expect(logs.warn.some((w: string) => w.includes('Unknown table cell align value'))).toBe(
+            true,
+        );
+    });
+
+    it('align="center" with unknown key "class" — only align is applied, unknown keys ignored', () => {
+        const tokens = parseTokens('#|\n||::{align="center" class="foo"} A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        const tdClass = tdOpens[0]?.attrGet('class') ?? '';
+        expect(tdClass).toContain('cell-align-center');
+        expect(tdClass).not.toContain('foo');
+    });
+
+    it('align does not appear as an HTML attribute on td', () => {
+        const tokens = parseTokens('#|\n||::{align="center"} A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        expect(tdOpens[0]?.attrGet('align')).toBeNull();
+    });
+});
+
+describe('deprecated cell-align class', () => {
+    beforeEach(() => {
+        log.clear();
+    });
+
+    it('|| Text {.cell-align-center} || emits deprecation warn and still applies class on td', () => {
+        const {
+            result: {html},
+            logs,
+        } = transform('#|\n|| Text {.cell-align-center} ||\n|#', {
+            plugins: [table],
+            enableMarkdownAttrs: false,
+        });
+        expect(html).toContain('<td class="cell-align-center">');
+        expect(
+            logs.warn.some((w: string) => w.includes('.cell-align-* class in cell content')),
+        ).toBe(true);
+    });
+
+    it('|| Text {.other-class} || does not emit deprecation warn', () => {
+        const {
+            result: {html},
+            logs,
+        } = transform('#|\n|| Text {.other-class} ||\n|#', {
+            plugins: [table],
+            enableMarkdownAttrs: false,
+        });
+        expect(html).toContain('<td class="other-class">');
+        expect(
+            logs.warn.some((w: string) => w.includes('.cell-align-* class in cell content')),
+        ).toBe(false);
     });
 });

--- a/test/table/table.test.ts
+++ b/test/table/table.test.ts
@@ -1,6 +1,7 @@
 import type {YfmTablePluginOptions} from '../../src/transform/plugins/table/types';
 
 import dd from 'ts-dedent';
+import MarkdownIt from 'markdown-it';
 
 import transform from '../../src/transform';
 import table from '../../src/transform/plugins/table';
@@ -1766,5 +1767,54 @@ describe('table with includes', () => {
                 '</tbody>\n' +
                 '</table>\n',
         );
+    });
+});
+
+describe('table attrs', () => {
+    const parseTokens = (text: string, opts?: YfmTablePluginOptions) => {
+        const md = new MarkdownIt();
+        md.use(table, opts ?? {});
+        return md.parse(text, {});
+    };
+
+    const findToken = (tokens: ReturnType<typeof parseTokens>, type: string) =>
+        tokens.find((t: {type: string}) => t.type === type);
+
+    it('parses single |:{key="value"} line into rawAttrs on yfm_table_open', () => {
+        const tokens = parseTokens('#|\n|:{key="value"}\n||A||\n|#');
+        const tableOpen = findToken(tokens, 'yfm_table_open');
+        expect(tableOpen?.meta?.rawAttrs).toEqual({key: 'value'});
+    });
+
+    it('later |:{...} lines override earlier ones for same key', () => {
+        const tokens = parseTokens('#|\n|:{key="first"}\n|:{key="second"}\n||A||\n|#');
+        const tableOpen = findToken(tokens, 'yfm_table_open');
+        expect(tableOpen?.meta?.rawAttrs).toEqual({key: 'second'});
+    });
+
+    it('empty |:{} results in rawAttrs === {}', () => {
+        const tokens = parseTokens('#|\n|:{}\n||A||\n|#');
+        const tableOpen = findToken(tokens, 'yfm_table_open');
+        expect(tableOpen?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('no attr lines results in rawAttrs === {}', () => {
+        const tokens = parseTokens('#|\n||A||\n|#');
+        const tableOpen = findToken(tokens, 'yfm_table_open');
+        expect(tableOpen?.meta?.rawAttrs).toEqual({});
+    });
+
+    it('|:{...} attrs do not appear in generated HTML', () => {
+        const html = transformYfm('#|\n|:{key="value"}\n||A||\n|#');
+        expect(html).not.toContain('|:{');
+        expect(html).not.toContain('key="value"');
+        expect(html).not.toContain('key=&quot;value&quot;');
+        expect(html).toContain('<table>');
+    });
+
+    it('duplicate key in single |:{...} line — last value wins', () => {
+        const tokens = parseTokens('#|\n|:{key="first" key="second"}\n||A||\n|#');
+        const tableOpen = findToken(tokens, 'yfm_table_open');
+        expect(tableOpen?.meta?.rawAttrs).toEqual({key: 'second'});
     });
 });


### PR DESCRIPTION
## Description

Adds a three-level attribute syntax to YFM tables — **table**, **row**, and **cell** — and introduces a semantic `align` attribute for cells as a replacement for the legacy `{.cell-align-*}` class syntax.

### Syntax

```md
#|
|:{class="data-table" id="users"}
||:{class="header"} ::{align="center"} Name | Age | City ||
||::{align="top-left"} Alice | 30 |::{align="top-right"} NYC ||
|| Bob | 25 | SF ||
|#
```

| Level | Marker | Stored on |
|-------|--------|-----------|
| Table | `\|:{ … }` on a dedicated line between `#\|` and the first `\|\|` | `yfm_table_open.meta.rawAttrs` |
| Row   | `\|\|:{ … }` on the same line as `\|\|` | `yfm_tr_open.meta.rawAttrs` |
| Cell  | `\|::{ … }` (or `::{ … }` after row-attrs for the first cell) | `yfm_td_open.meta.rawAttrs` |

Raw attributes are stored verbatim as `Record<string, string>` in `token.meta.rawAttrs`. Downstream consumers can read this metadata to drive custom behavior. Unknown attribute keys are **not** propagated to `token.attrs` and therefore do not appear in the rendered HTML — only `align` is interpreted by the plugin into HTML output.

### Key rules

- **Single-line constraint.** Every attribute block must live on the same line as its separator. A newline between `||` / `|` and the attribute block disqualifies it — the text becomes cell content.
- **Row-attrs flush.** `:{` must sit immediately after `||`; whitespace in between disqualifies it.
- **First-cell attrs.** After `||:{…}`, optional WSP/tabs on the same line are allowed before `::{…}`.
- **Non-first cell attrs.** `::{` must sit flush against `|` — no whitespace allowed.
- **Table-attr lines** may appear multiple times between `#|` and the first `||`; later keys overwrite earlier ones.

### `align` attribute (replaces `{.cell-align-*}`)

The new `align` attribute is introduced as a dedicated replacement for the legacy `{.cell-align-*}` class syntax in cell content. It applies to cells only and produces a `cell-align-<value>` class on `<td>` via `attrJoin` (preserves existing classes). The attribute itself is emitted as the HTML attribute `data-align` for the `<td>`.

Recognized values (sourced from [src/scss/_table.scss](../blob/master/src/scss/_table.scss)):
`top-left`, `top-center`, `top-right`, `center`, `bottom-left`, `bottom-right`.

Unknown values still produce the class (for custom stylesheets) but emit `log.warn('Unknown table cell align value: "..."')`.

The legacy form continues to work for backward compatibility:

```md
|| Text {.cell-align-center} ||
```

…but now emits a deprecation warning recommending `::{align="center"}`. Other classes in trailing `{ … }` blocks do not trigger the warning, keeping backward compatibility for all other uses.
