### PR TITLE
feat(table): add bg attribute for cells

### DIFF
--- a/src/transform/plugins/table/index.ts
+++ b/src/transform/plugins/table/index.ts
@@ -543,7 +543,7 @@ function extractAndApplyClassFromToken(contentToken: Token, tdOpenToken: Token, 
                 `Deprecated: use align="..." inside cell attributes "::{align=\\"...\\"}" instead of .cell-align-* class in cell content "{ }"`,
             );
         }
-        tdOpenToken.attrSet('class', attrsClass);
+        tdOpenToken.attrJoin('class', attrsClass);
         // remove the class from the token so that it's not propagated to tr or table level
         let replacedContent = allAttrs[0].replace(`.${attrsClass}`, '');
         if (replacedContent.trim() === '{}') {
@@ -573,6 +573,16 @@ function applyCellAttrs(token: Token, rawAttrs: TableAttrs, log: Logger): void {
         token.attrSet('data-align', value);
         if (value) {
             token.attrJoin('class', `cell-align-${value}`);
+        }
+    }
+
+    if ('bg' in rawAttrs) {
+        const value = rawAttrs['bg'];
+        token.meta = token.meta || {};
+        token.meta.bg = value;
+        token.attrSet('data-bg', value);
+        if (value) {
+            token.attrJoin('class', `cell-bg-${value}`);
         }
     }
 }

--- a/test/table/table.test.ts
+++ b/test/table/table.test.ts
@@ -2082,3 +2082,80 @@ describe('deprecated cell-align class', () => {
         ).toBe(false);
     });
 });
+
+describe('cell bg attribute', () => {
+    const parseTokens = (text: string, opts?: YfmTablePluginOptions) => {
+        const md = new MarkdownIt();
+        md.use(table, opts ?? {});
+        return md.parse(text, {});
+    };
+
+    it('||::{bg="red"} A || sets meta.bg and meta.rawAttrs on yfm_td_open', () => {
+        const tokens = parseTokens('#|\n||::{bg="red"} A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        expect(tdOpens[0]?.meta?.bg).toBe('red');
+        expect(tdOpens[0]?.meta?.rawAttrs).toEqual({bg: 'red'});
+    });
+
+    it('|| A || (no bg) — meta.bg is undefined', () => {
+        const tokens = parseTokens('#|\n|| A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        expect(tdOpens[0]?.meta?.bg).toBeUndefined();
+    });
+
+    it('adds cell-bg-<value> class on td token', () => {
+        const tokens = parseTokens('#|\n||::{bg="red"} A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        expect(tdOpens[0]?.attrGet('class')).toBe('cell-bg-red');
+    });
+
+    it('adds data-bg="<value>" attribute on td token', () => {
+        const tokens = parseTokens('#|\n||::{bg="red"} A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        expect(tdOpens[0]?.attrGet('data-bg')).toBe('red');
+    });
+
+    it('||::{bg=""} A || — empty value: only data-bg set, no cell-bg- class', () => {
+        const tokens = parseTokens('#|\n||::{bg=""} A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        expect(tdOpens[0]?.meta?.bg).toBe('');
+        expect(tdOpens[0]?.attrGet('data-bg')).toBe('');
+        expect(tdOpens[0]?.attrGet('class') ?? '').not.toContain('cell-bg-');
+    });
+
+    it('bg + align: both classes present on td token', () => {
+        const tokens = parseTokens('#|\n||::{bg="red" align="center"} A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        const cls = tdOpens[0]?.attrGet('class') ?? '';
+        expect(cls).toContain('cell-align-center');
+        expect(cls).toContain('cell-bg-red');
+    });
+
+    it('bg + deprecated {.cell-align-center}: both classes present on td', () => {
+        const html = transformYfm('#|\n||::{bg="red"} A {.cell-align-center} ||\n|#');
+        expect(html).toContain('cell-align-center');
+        expect(html).toContain('cell-bg-red');
+    });
+
+    it('cells without bg are not affected', () => {
+        const tokens = parseTokens('#|\n|| A ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        expect(tdOpens[0]?.attrGet('class')).toBeNull();
+        expect(tdOpens[0]?.attrGet('data-bg')).toBeNull();
+    });
+
+    it('multiple cells with different bg values', () => {
+        const tokens = parseTokens('#|\n||::{bg="red"} A |::{bg="blue"} B ||\n|#');
+        const tdOpens = tokens.filter((t: {type: string}) => t.type === 'yfm_td_open');
+        expect(tdOpens[0]?.attrGet('class')).toBe('cell-bg-red');
+        expect(tdOpens[0]?.attrGet('data-bg')).toBe('red');
+        expect(tdOpens[1]?.attrGet('class')).toBe('cell-bg-blue');
+        expect(tdOpens[1]?.attrGet('data-bg')).toBe('blue');
+    });
+
+    it('::{bg} does not leak into cell content HTML', () => {
+        const html = transformYfm('#|\n||::{bg="red"} Text ||\n|#');
+        expect(html).not.toContain('::{');
+        expect(html).toContain('<p>Text</p>');
+    });
+});


### PR DESCRIPTION
## Description

Adds `bg` attribute support for table cells via the cell attribute syntax `::{bg="..."}`.

### Usage

```
#|
|| ::{bg="gray"} Cell with gray background | Normal cell ||
|#
```

### Behavior

* Sets `data-bg="<value>"` on the `<td>` element
* Adds `cell-bg-<value>` CSS class to `<td>` via `attrJoin` (preserves existing classes)
* Stores the value in `token.meta.bg` for downstream consumers
* No validation on the value — any string is accepted (custom stylesheets can define their own `cell-bg-*` classes)