### PR TITLE
fix: fixed terms in includes

### DIFF
--- a/src/transform/plugins/term/index.ts
+++ b/src/transform/plugins/term/index.ts
@@ -251,6 +251,15 @@ function removeUnreferencedDefinitions(tokens: Token[], referencedTerms: Set<str
     }
 }
 
+/**
+ * Eagerly initialize env.terms before the includes core rule runs
+ */
+function termInit(state: StateCore) {
+    if (!state.env.terms) {
+        state.env.terms = {};
+    }
+}
+
 const term: MarkdownItPluginCb = (md, options) => {
     const escapeRE = md.utils.escapeRE;
     const arrayReplaceAt = md.utils.arrayReplaceAt;
@@ -404,13 +413,6 @@ const term: MarkdownItPluginCb = (md, options) => {
     md.block.ruler.before('reference', 'termDefinitions', termDefinitions(md, options), {
         alt: ['paragraph', 'reference'],
     });
-
-    // Eagerly initialize env.terms before includes resolve.
-    function termInit(state: StateCore) {
-        if (!state.env.terms) {
-            state.env.terms = {};
-        }
-    }
 
     try {
         md.core.ruler.before('includes', 'termInit', termInit);

--- a/src/transform/plugins/term/index.ts
+++ b/src/transform/plugins/term/index.ts
@@ -391,9 +391,12 @@ const term: MarkdownItPluginCb = (md, options) => {
             }
         }
 
-        // Remove definitions without any reference on the page
-        // Skip during linting to allow lint rules to check term definitions
-        if (!isLintRun) {
+        // Remove definitions without any reference on the page.
+        // Skip during linting to allow lint rules to check term definitions.
+        // Skip when inside an include sub-parse (env.includes is non-empty)
+        const insideInclude = Array.isArray(state.env.includes) && state.env.includes.length > 0;
+
+        if (!isLintRun && !insideInclude) {
             removeUnreferencedDefinitions(state.tokens, referencedTerms);
         }
     }
@@ -401,6 +404,17 @@ const term: MarkdownItPluginCb = (md, options) => {
     md.block.ruler.before('reference', 'termDefinitions', termDefinitions(md, options), {
         alt: ['paragraph', 'reference'],
     });
+
+    // Eagerly initialize env.terms before includes resolve.
+    function termInit(state: StateCore) {
+        if (!state.env.terms) {
+            state.env.terms = {};
+        }
+    }
+
+    try {
+        md.core.ruler.before('includes', 'termInit', termInit);
+    } catch {}
 
     // Register termReplace after text_join so that emphasis-split text
     // tokens (e.g. [text](*key) where * opens a delimiter) are merged

--- a/test/mocks/term/_includes/glossary.md
+++ b/test/mocks/term/_includes/glossary.md
@@ -1,0 +1,1 @@
+[*html]: HyperText Markup Language

--- a/test/mocks/term/includeDefinitions.md
+++ b/test/mocks/term/includeDefinitions.md
@@ -1,0 +1,5 @@
+{% include [glossary](_includes/glossary.md) %}
+
+# Web
+
+The [HTML](*html) specification

--- a/test/term.test.ts
+++ b/test/term.test.ts
@@ -82,6 +82,16 @@ describe('Terms', () => {
         expect(clearRandomId(result)).toMatchSnapshot();
     });
 
+    test('Term should be interactive when definition comes entirely from included file', () => {
+        const inputPath = resolve(__dirname, './mocks/term/includeDefinitions.md');
+        const input = readFileSync(inputPath, 'utf8');
+        const result = transformYfm(input, inputPath);
+
+        expect(result).toContain('term-key=":html"');
+        expect(result).toContain('id=":html_element"');
+        expect(result).toContain('yfm-term_title');
+    });
+
     test('Term should use escape regexp like chars', () => {
         const inputPath = resolve(__dirname, './mocks/term/rxlike-term.md');
         const input = readFileSync(inputPath, 'utf8');


### PR DESCRIPTION
Added a core termInit rule that runs before includes and creates an empty env.terms object = {}.