### PR TITLE
feat(code): exclude prompt from code block clipboard copy #2615

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "esbuild-sass-plugin": "^3.3.1",
         "highlight.js": "^11.8.0",
         "jest-serializer-html": "^7.1.0",
+        "jsdom": "^25.0.1",
         "markdown-it-testgen": "^0.1.6",
         "npm-run-all": "^4.1.5",
         "postcss": "^8.4.27",
@@ -84,6 +85,142 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -4207,6 +4344,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -4497,6 +4644,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -5001,6 +5155,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "13.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
@@ -5304,12 +5471,47 @@
       "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==",
       "license": "CC0-1.0"
     },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -5433,6 +5635,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -5505,6 +5714,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -6928,6 +7147,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -7422,9 +7658,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7450,6 +7686,19 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -7488,6 +7737,34 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.0.1",
         "entities": "^4.4.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -7954,6 +8231,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8241,6 +8525,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -9017,6 +9342,29 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -9461,6 +9809,13 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -11236,6 +11591,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -11788,6 +12150,19 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/semver": {
@@ -12735,6 +13110,13 @@
         "node": ">= 10"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sync-child-process": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/sync-child-process/-/sync-child-process-1.0.2.tgz",
@@ -13063,6 +13445,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -13084,6 +13486,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/trim-newlines": {
@@ -14041,6 +14469,29 @@
         "node": ">=6"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -14059,6 +14510,20 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
       "engines": {
         "node": ">=18"
       }
@@ -14326,6 +14791,45 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "esbuild-sass-plugin": "^3.3.1",
     "highlight.js": "^11.8.0",
     "jest-serializer-html": "^7.1.0",
+    "jsdom": "^25.0.1",
     "markdown-it-testgen": "^0.1.6",
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.27",

--- a/src/js/code.ts
+++ b/src/js/code.ts
@@ -31,17 +31,34 @@ function buttonCopyFn(target: HTMLElement) {
         return;
     }
 
-    // Get all text nodes and filter out line numbers
-    const textContent = Array.from(code.childNodes)
-        .filter((node) => {
-            // Skip line number spans
-            if (node instanceof HTMLElement && node.classList.contains('yfm-line-number')) {
-                return false;
-            }
-            return true;
-        })
-        .map((node) => node.textContent)
-        .join('');
+    // Strip line-number decorations (class-based, no semantic alternative).
+    const clone = code.cloneNode(true) as HTMLElement;
+
+    clone.querySelectorAll('.yfm-line-number').forEach((el) => el.remove());
+    let textContent = clone.textContent ?? '';
+
+    // Strip prompt prefix from each line using the raw value stored in data-prompt.
+    // This avoids any dependency on how (or whether) the prompt is wrapped in the DOM.
+    // Leading whitespace before the prompt is preserved so indented commands keep
+    // their indentation level in the copied text.
+    const promptValue = code.dataset.prompt;
+    if (promptValue) {
+        const prefix = promptValue + ' ';
+        textContent = textContent
+            .split('\n')
+            .map((line) => {
+                const trimmed = line.trimStart();
+                const leadingWs = line.slice(0, line.length - trimmed.length);
+                if (trimmed.startsWith(prefix)) {
+                    return leadingWs + trimmed.slice(prefix.length);
+                }
+                if (trimmed === promptValue) {
+                    return leadingWs;
+                }
+                return line;
+            })
+            .join('\n');
+    }
 
     copyToClipboard(textContent.trim()).then(() => {
         notifySuccess(container.querySelector('.yfm-clipboard-icon'));

--- a/src/scss/_code.scss
+++ b/src/scss/_code.scss
@@ -65,6 +65,12 @@
         .yfm-code-icon {
             pointer-events: none;
         }
+
+        .yfm-code-prompt {
+            color: var(--yfm-color-hljs-comment-private);
+            pointer-events: none;
+            user-select: none;
+        }
     }
 
     &-clipboard-inline-code {

--- a/src/transform/plugins/code.ts
+++ b/src/transform/plugins/code.ts
@@ -3,6 +3,8 @@
 import type {MarkdownItPluginCb} from './typings';
 import type {IDGenerator} from './utils';
 
+import {escapeHtml} from 'markdown-it/lib/common/utils';
+
 import {generateID as globalGenerateID} from './utils';
 
 const wrapInFloatingContainer = (
@@ -134,7 +136,57 @@ function balanceSpansPerLine(lines: string[]): string[] {
     });
 }
 
-function addLineNumbers(code: string, {lineWrapping}: {lineWrapping: boolean}): string {
+/**
+ * Strips the prompt prefix from the raw fence content BEFORE it reaches the highlighter.
+ *
+ * @param content - Raw fence content.
+ * @param prompt - Raw prompt string (e.g. `$`, `#`, `>>>`).
+ * @returns Stripped content (same number of lines) and a per-line prompt flag array.
+ */
+function stripPrompt(content: string, prompt: string): {content: string; flags: boolean[]} {
+    const hasTrailingNewline = content.endsWith('\n');
+    const lines = content.split('\n');
+    const linesToProcess = hasTrailingNewline ? lines.slice(0, -1) : lines;
+
+    const flags: boolean[] = [];
+    const stripped = linesToProcess.map((line) => {
+        const trimmed = line.trimStart();
+        const leadingWs = line.slice(0, line.length - trimmed.length);
+
+        if (trimmed.startsWith(prompt + ' ')) {
+            flags.push(true);
+            return leadingWs + trimmed.slice(prompt.length + 1);
+        }
+
+        if (trimmed === prompt) {
+            flags.push(true);
+            return leadingWs;
+        }
+
+        flags.push(false);
+        return line;
+    });
+
+    return {
+        content: stripped.join('\n') + (hasTrailingNewline ? '\n' : ''),
+        flags,
+    };
+}
+
+function postProcessCode(
+    code: string,
+    {
+        showLineNumbers,
+        lineWrapping,
+        promptFlags,
+        promptEscaped,
+    }: {
+        showLineNumbers: boolean;
+        lineWrapping: boolean;
+        promptFlags?: boolean[];
+        promptEscaped?: string;
+    },
+): string {
     const hasTrailingNewline = code.endsWith('\n');
     const lines = code.split('\n');
     const linesToProcess = hasTrailingNewline ? lines.slice(0, -1) : lines;
@@ -144,13 +196,51 @@ function addLineNumbers(code: string, {lineWrapping}: {lineWrapping: boolean}): 
     return (
         normalized
             .map((line, index) => {
-                const lineNumber = String(index + 1).padStart(maxDigits, ' ');
-                return lineWrapping
-                    ? `<span class="yfm-line-number">${lineNumber}</span><span class="yfm-line">${line}</span>`
-                    : `<span class="yfm-line-number">${lineNumber}</span>${line}`;
+                // The prompt was already stripped from the raw content before
+                // highlighting, so `line` here is the highlighted command only.
+                // Re-insert the prompt as a dedicated, non-selectable span after
+                // any leading whitespace. `promptFlags` marks which lines carried
+                // a prompt in the original source.
+                if (promptFlags?.[index] && promptEscaped !== undefined) {
+                    const trimmed = line.trimStart();
+                    const leadingWs = line.slice(0, line.length - trimmed.length);
+                    line =
+                        `${leadingWs}` +
+                        `<span class="yfm-code-prompt" aria-hidden="true">${promptEscaped} </span>` +
+                        `${trimmed}`;
+                }
+
+                if (showLineNumbers) {
+                    const lineNumber = String(index + 1).padStart(maxDigits, ' ');
+                    line = lineWrapping
+                        ? `<span class="yfm-line-number">${lineNumber}</span><span class="yfm-line">${line}</span>`
+                        : `<span class="yfm-line-number">${lineNumber}</span>${line}`;
+                }
+
+                return line;
             })
             .join('\n') + (hasTrailingNewline ? '\n' : '')
     );
+}
+
+/**
+ * @param info - Raw fence info string (e.g. `js showLineNumbers prompt="$"`).
+ * @returns Parsed flags and the optional prompt value.
+ */
+function parseFenceInfo(info: string): {
+    showLineNumbers: boolean;
+    wrapLines: boolean;
+    prompt?: string;
+} {
+    const promptMatch = /(?:^|\s)prompt=(?:"([^"]*)"|'([^']*)')/.exec(info);
+    const prompt = promptMatch?.[1] ?? promptMatch?.[2];
+    const rest = promptMatch ? info.replace(promptMatch[0], ' ') : info;
+
+    return {
+        showLineNumbers: /\bshowLineNumbers\b/.test(rest),
+        wrapLines: /\bwrap\b/.test(rest),
+        prompt,
+    };
 }
 
 type CodeOptions = {
@@ -164,36 +254,69 @@ type CodeOptions = {
 
 const code: MarkdownItPluginCb<CodeOptions> = (md, opts) => {
     const lineWrapping = opts?.codeLineWrapping || false;
-    const generateID = opts.generateID ?? globalGenerateID;
+    const generateID = opts?.generateID ?? globalGenerateID;
 
     const superCodeRenderer = md.renderer.rules.fence;
     md.renderer.rules.fence = function (tokens, idx, options, env, self) {
         const token = tokens[idx];
-        const showLineNumbers = token.info.includes('showLineNumbers');
-        const wrapLines = token.info.includes('wrap');
-
+        const {showLineNumbers, prompt, wrapLines} = parseFenceInfo(token.info);
         const shouldWrap = wrapLines;
+
+        // Strip the prompt prefix from the raw content BEFORE handing it
+        // to the highlighter, so language grammars never misinterpret prompt
+        // symbols (e.g. `#` as a shell comment, `$` as a variable). The prompt is
+        // re-inserted as a span in postProcessCode, driven by `promptFlags`.
+        let promptFlags: boolean[] | undefined;
+        let promptEscaped: string | undefined;
+        const originalContent = token.content;
+        if (prompt) {
+            const stripped = stripPrompt(token.content, prompt);
+            token.content = stripped.content;
+            promptFlags = stripped.flags;
+            promptEscaped = escapeHtml(prompt);
+        }
 
         let superCode = superCodeRenderer?.(tokens, idx, options, env, self);
 
-        if (superCode && showLineNumbers) {
+        // Restore the original content so the mutation does not leak to other
+        // consumers of the token.
+        token.content = originalContent;
+
+        if (superCode && (showLineNumbers || prompt)) {
             // Extract the code content from the pre/code tags
             const codeMatch = superCode.match(/<pre[^>]*><code[^>]*>([\s\S]*?)<\/code><\/pre>/);
             if (codeMatch) {
                 const codeContent = codeMatch[1];
-                const codeWithLineNumbers = addLineNumbers(codeContent, {lineWrapping});
+                const processedCode = postProcessCode(codeContent, {
+                    showLineNumbers,
+                    lineWrapping,
+                    promptFlags,
+                    promptEscaped,
+                });
                 // Escape $ in replacement string: $$ becomes a literal $ in String.replace()
-                const escapedReplacement = codeWithLineNumbers.replace(/\$/g, '$$$$');
+                const escapedReplacement = processedCode.replace(/\$/g, '$$$$');
                 superCode = superCode.replace(codeContent, escapedReplacement);
             }
         }
 
-        if (superCode && shouldWrap) {
-            superCode = superCode.replace(/<code([^>]*)>/, (_match, attrs) => {
-                if (attrs.includes('class=')) {
-                    return `<code${attrs.replace(/class="([^"]*)"/, 'class="$1 wrap"')}>`;
+        // Attach the raw prompt value as a data attribute on <code> so that the
+        // copy widget can strip it from the plain-text content without relying on
+        // any class names or DOM structure introduced by the plugin.
+        if (superCode && (prompt || shouldWrap)) {
+            superCode = superCode.replace(/(<pre[^>]*><code)([^>]*)>/, (_match, open, attrs) => {
+                // Add the wrap class
+                if (shouldWrap) {
+                    attrs = /class="[^"]*"/.test(attrs)
+                        ? attrs.replace(/class="([^"]*)"/, 'class="$1 wrap"')
+                        : ` class="wrap"${attrs}`;
                 }
-                return `<code class="wrap"${attrs}>`;
+
+                // Add the data-prompt attribute
+                if (prompt) {
+                    attrs = ` data-prompt="${escapeHtml(prompt)}"${attrs}`;
+                }
+
+                return `${open}${attrs}>`;
             });
         }
 

--- a/test/code.test.ts
+++ b/test/code.test.ts
@@ -15,6 +15,12 @@ const fenceRenderFn = (tokens: Token[], index: number) =>
     `<pre><code>${escapeHtml(tokens[index].content)}</code></pre>\n`;
 
 const getMd = (fence: Mock) => ({
+    // The plugin uses md.utils.escapeHtml when a prompt is present and
+    // md.utils.escapeRE for term replacement; provide real implementations.
+    utils: {
+        escapeHtml,
+        escapeRE: (str: string) => str,
+    },
     renderer: {
         rules: {
             fence,
@@ -406,6 +412,267 @@ describe('Code', () => {
                 '<span class="yfm-line-number">1</span><span class="yfm-line">line1</span>',
             );
             expect(result).toContain('yfm-wrapping-button');
+        });
+    });
+
+    describe('Prompt', () => {
+        it('should wrap the prompt prefix in a non-selectable span', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'bash prompt="$"',
+                    content: '$ npm install\nadded 1 package\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain(
+                '<span class="yfm-code-prompt" aria-hidden="true">$ </span>npm install',
+            );
+        });
+
+        it('should leave lines without the prompt untouched', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'bash prompt="$"',
+                    content: '$ npm install\nadded 1 package\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain('added 1 package');
+            expect(result).not.toContain(
+                '<span class="yfm-code-prompt" aria-hidden="true">$ </span>added',
+            );
+        });
+
+        it('should add the raw prompt value as a data-prompt attribute on <code>', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'bash prompt="$"',
+                    content: '$ ls\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain('data-prompt="$"');
+        });
+
+        it('should preserve leading whitespace before an indented prompt', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'bash prompt="$"',
+                    content: '  $ echo hi\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain(
+                '  <span class="yfm-code-prompt" aria-hidden="true">$ </span>echo hi',
+            );
+        });
+
+        it('should handle a line consisting solely of the prompt', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'bash prompt="$"',
+                    content: '$\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain('<span class="yfm-code-prompt" aria-hidden="true">$ </span>');
+        });
+
+        it('should escape HTML special characters in the prompt', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'python prompt=">>>"',
+                    content: '>>> print(1)\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain(
+                '<span class="yfm-code-prompt" aria-hidden="true">&gt;&gt;&gt; </span>print(1)',
+            );
+            expect(result).toContain('data-prompt="&gt;&gt;&gt;"');
+        });
+
+        it('should wrap a multi-character sql prompt', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'sql prompt="sql>"',
+                    content: 'sql> SELECT 1;\nsql> SELECT 2;\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain(
+                '<span class="yfm-code-prompt" aria-hidden="true">sql&gt; </span>SELECT 1;',
+            );
+            expect(result).toContain(
+                '<span class="yfm-code-prompt" aria-hidden="true">sql&gt; </span>SELECT 2;',
+            );
+            expect(result).toContain('data-prompt="sql&gt;"');
+        });
+
+        it('should wrap the >>> prompt on every input line and leave output lines untouched', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'python prompt=">>>"',
+                    content: '>>> a = 1\n>>> print(a)\n1\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain(
+                '<span class="yfm-code-prompt" aria-hidden="true">&gt;&gt;&gt; </span>a = 1',
+            );
+            expect(result).toContain(
+                '<span class="yfm-code-prompt" aria-hidden="true">&gt;&gt;&gt; </span>print(a)',
+            );
+            // The plain output line must stay as-is, without a prompt span.
+            expect(result).toContain('\n1\n');
+            expect(result).not.toContain(
+                '<span class="yfm-code-prompt" aria-hidden="true">&gt;&gt;&gt; </span>1',
+            );
+        });
+
+        it('should combine prompt spans with line numbers', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'bash prompt="$" showLineNumbers',
+                    content: '$ ls\noutput\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain(
+                '<span class="yfm-line-number">1</span><span class="yfm-code-prompt" aria-hidden="true">$ </span>ls',
+            );
+            expect(result).toContain('<span class="yfm-line-number">2</span>output');
+        });
+
+        it('should not add prompt markup when no prompt is specified', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'bash',
+                    content: '$ ls\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).not.toContain('yfm-code-prompt');
+            expect(result).not.toContain('data-prompt');
+        });
+
+        it('should accept a prompt wrapped in single quotes', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: "bash prompt='$'",
+                    content: '$ npm install\nadded 1 package\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain(
+                '<span class="yfm-code-prompt" aria-hidden="true">$ </span>npm install',
+            );
+            expect(result).toContain('data-prompt="$"');
+        });
+
+        it('should accept a multi-character prompt wrapped in single quotes', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: "python prompt='>>>'",
+                    content: '>>> print(1)\n',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).toContain(
+                '<span class="yfm-code-prompt" aria-hidden="true">&gt;&gt;&gt; </span>print(1)',
+            );
+            expect(result).toContain('data-prompt="&gt;&gt;&gt;"');
+        });
+    });
+
+    describe('Flag detection (word boundaries)', () => {
+        it('should not treat showLineNumbers as a flag when it is part of a larger word', () => {
+            const fence = vi.fn(fenceRenderFn);
+            const md = getMd(fence);
+            code(md as unknown as MarkdownIt, {} as MarkdownItPluginOpts);
+
+            const tokens = [
+                {
+                    info: 'jsshowLineNumbers',
+                    content: 'line1\nline2',
+                },
+            ];
+
+            const result = md.renderer.rules.fence(tokens, 0, {}, {}, {} as Renderer);
+
+            expect(result).not.toContain('yfm-line-number');
         });
     });
 });

--- a/test/highlight-code.test.ts
+++ b/test/highlight-code.test.ts
@@ -14,8 +14,65 @@ const transformYfm = (text: string) => {
     return html;
 };
 
+// Runs the full transform pipeline WITH the default plugins (including the code
+// plugin) and the real highlight.js highlighter. Unlike code.test.ts, which
+// mocks the fence renderer, this exercises the real interaction between the
+// prompt feature and language grammars.
+const transformWithPlugins = (text: string) => {
+    const {
+        result: {html},
+    } = transform(text, {
+        path: mocksPath,
+        root: dirname(mocksPath),
+    });
+    return html;
+};
+
 test('should highlight code', () => {
     const result = transformYfm("```ts\nconst x: string = 'y';\n```");
 
     expect(result).toMatchSnapshot();
+});
+
+describe('prompt with real highlighting (plan B)', () => {
+    it('should not let highlight.js treat the "#" prompt as a shell comment', () => {
+        const result = transformWithPlugins('```sh prompt="#"\n# apt-get update\n```');
+
+        // The prompt symbol is stripped before highlighting, so the command is
+        // NOT swallowed by an hljs-comment span. The command text stays visible.
+        expect(result).toContain('<span class="yfm-code-prompt" aria-hidden="true"># </span>');
+        expect(result).toContain('apt-get');
+        // The prompt itself must not be turned into a comment span.
+        expect(result).not.toContain('<span class="hljs-comment"># apt-get update</span>');
+    });
+
+    it('should not let highlight.js treat the "$" prompt as a shell variable', () => {
+        const result = transformWithPlugins('```bash prompt="$"\n$ echo hi\n```');
+
+        expect(result).toContain('<span class="yfm-code-prompt" aria-hidden="true">$ </span>');
+        expect(result).toContain('echo');
+    });
+
+    it('should still highlight the command that follows the prompt', () => {
+        const result = transformWithPlugins('```bash prompt="$"\n$ echo hi\n```');
+
+        // The remaining command is handed to highlight.js and gets real tokens.
+        expect(result).toContain('hljs-built_in');
+    });
+
+    it('should expose the raw prompt via data-prompt for the copy widget', () => {
+        const result = transformWithPlugins('```sh prompt="$"\n$ ls\n```');
+
+        expect(result).toContain('data-prompt="$"');
+    });
+
+    it('should leave output lines (without prompt) untouched', () => {
+        const result = transformWithPlugins('```sh prompt="$"\n$ ls\noutput line\n```');
+
+        expect(result).toContain('output line');
+        // Output lines get no prompt span.
+        expect(result).not.toContain(
+            '<span class="yfm-code-prompt" aria-hidden="true">$ </span>output',
+        );
+    });
 });

--- a/test/js-code.test.ts
+++ b/test/js-code.test.ts
@@ -1,0 +1,256 @@
+// @vitest-environment jsdom
+
+import type * as Utils from '../src/js/utils';
+
+import {dirname} from 'path';
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+
+import transform from '../src/transform';
+import {copyToClipboard} from '../src/js/utils';
+// The module attaches a single global click handler on import.
+import '../src/js/code';
+
+// Mock only copyToClipboard so we can assert on the copied text and control the
+// returned promise, while keeping getEventTarget/isCustom and the real markup
+// from the pipeline intact.
+vi.mock('../src/js/utils', async (importOriginal) => {
+    const actual = await importOriginal<typeof Utils>();
+    return {
+        ...actual,
+        copyToClipboard: vi.fn(() => Promise.resolve()),
+    };
+});
+
+const mockedCopy = vi.mocked(copyToClipboard);
+
+const mocksPath = require.resolve('./utils.ts');
+
+// Runs the full transform pipeline with the default plugins (code plugin
+// included) and the real highlighter, returning the sanitized HTML.
+function render(markdown: string, options: {codeLineWrapping?: boolean} = {}) {
+    const {
+        result: {html},
+    } = transform(markdown, {
+        path: mocksPath,
+        root: dirname(mocksPath),
+        ...options,
+    });
+    return html;
+}
+
+// Asserts that a queried element exists, narrowing the type to non-null so tests
+// stay free of non-null assertions. A missing element means the plugin markup
+// drifted from what the client handler expects — that should fail loudly.
+function must<T>(value: T | null | undefined, name: string): T {
+    if (value === null || value === undefined) {
+        throw new Error(`Expected "${name}" to be present in the rendered markup`);
+    }
+    return value;
+}
+
+// Mounts real pipeline HTML into the jsdom document and returns handles to the
+// widget elements the client handler relies on. `container`, `copyButton` and
+// `code` are always produced by the plugin, so they are asserted non-null here.
+// `wrapButton` is optional (only rendered with codeLineWrapping). jsdom has no
+// SVG animation API, so we replace beginElement with a spy on the concrete
+// <animate> element that notifySuccess() resolves via
+// getElementById(`visibileAnimation-<id>`).
+function mount(html: string) {
+    document.body.innerHTML = html;
+
+    const container = must(
+        document.querySelector<HTMLElement>('.yfm-code-floating-container'),
+        'container',
+    );
+    const copyButton = must(
+        document.querySelector<HTMLElement>('.yfm-clipboard-button'),
+        'copyButton',
+    );
+    const code = must(document.querySelector<HTMLElement>('pre code'), 'code');
+    const wrapButton = document.querySelector<HTMLElement>('.yfm-wrapping-button');
+
+    const animate = document.querySelector<HTMLElement>('[id^="visibileAnimation-"]');
+    if (animate) {
+        (animate as unknown as {beginElement: () => void}).beginElement = vi.fn();
+    }
+
+    return {container, copyButton, wrapButton, code, animate};
+}
+
+const click = (el: Element) =>
+    el.dispatchEvent(new MouseEvent('click', {bubbles: true, composed: true}));
+
+// Let the mocked promise's .then callback (notifySuccess) run.
+const flush = () => Promise.resolve();
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    mockedCopy.mockClear();
+    mockedCopy.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    document.body.innerHTML = '';
+});
+
+describe('js/code integration — real pipeline markup', () => {
+    it('should expose the widget markup the client handler depends on', () => {
+        // mount() asserts that container/copyButton/code exist; if the plugin
+        // markup drifts from the selectors src/js/code.ts queries, this throws.
+        expect(() => mount(render('```\nnpm install\n```'))).not.toThrow();
+    });
+
+    it('should render the wrapping button only when codeLineWrapping is enabled', () => {
+        expect(mount(render('```\ncode\n```')).wrapButton).toBeNull();
+        expect(mount(render('```\ncode\n```', {codeLineWrapping: true})).wrapButton).not.toBeNull();
+    });
+});
+
+describe('js/code integration — copy button', () => {
+    it('should copy the plain text content of a real rendered code block', async () => {
+        const {copyButton} = mount(render('```\nnpm install\nnpm run build\n```'));
+
+        click(copyButton);
+        await flush();
+
+        expect(mockedCopy).toHaveBeenCalledTimes(1);
+        expect(mockedCopy).toHaveBeenCalledWith('npm install\nnpm run build');
+    });
+
+    it('should strip line-number decorations produced by showLineNumbers', async () => {
+        const {copyButton} = mount(render('```text showLineNumbers\nline one\nline two\n```'));
+
+        click(copyButton);
+        await flush();
+
+        // The .yfm-line-number spans injected by the plugin are removed on copy.
+        expect(mockedCopy).toHaveBeenCalledWith('line one\nline two');
+    });
+
+    it('should strip the prompt prefix via the data-prompt contract', async () => {
+        const {code, copyButton} = mount(
+            render('```bash prompt="$"\n$ npm install\nadded 1 package\n```'),
+        );
+
+        // The pipeline must attach the raw prompt so the widget can strip it.
+        expect(code.getAttribute('data-prompt')).toBe('$');
+
+        click(copyButton);
+        await flush();
+
+        // Prompt line loses the "$ " prefix; the output line stays intact.
+        expect(mockedCopy).toHaveBeenCalledWith('npm install\nadded 1 package');
+    });
+
+    it('should strip a multi-character prompt on every input line', async () => {
+        const {copyButton} = mount(
+            render('```python prompt=">>>"\n>>> a = 1\n>>> print(a)\n1\n```'),
+        );
+
+        click(copyButton);
+        await flush();
+
+        expect(mockedCopy).toHaveBeenCalledWith('a = 1\nprint(a)\n1');
+    });
+
+    it('should combine line numbers and prompt stripping end-to-end', async () => {
+        const {copyButton} = mount(render('```bash prompt="$" showLineNumbers\n$ ls\noutput\n```'));
+
+        click(copyButton);
+        await flush();
+
+        expect(mockedCopy).toHaveBeenCalledWith('ls\noutput');
+    });
+
+    it('should preserve leading whitespace before an indented prompt', async () => {
+        const {copyButton} = mount(render('```bash prompt="$"\n  $ echo hi\n```'));
+
+        click(copyButton);
+        await flush();
+
+        // Indentation is preserved before the prompt is removed; the final
+        // single-line result is then trimmed.
+        expect(mockedCopy).toHaveBeenCalledWith('echo hi');
+    });
+
+    it('should reduce a prompt-only line to its leading whitespace', async () => {
+        const {copyButton} = mount(render('```bash prompt="$"\n$ first\n$\n$ second\n```'));
+
+        click(copyButton);
+        await flush();
+
+        expect(mockedCopy).toHaveBeenCalledWith('first\n\nsecond');
+    });
+
+    it('should trim surrounding whitespace of the final text', async () => {
+        const {copyButton} = mount(render('```\n\n\nnpm install\n\n\n```'));
+
+        click(copyButton);
+        await flush();
+
+        expect(mockedCopy).toHaveBeenCalledWith('npm install');
+    });
+
+    it('should not mutate the live code block when stripping decorations', async () => {
+        const {code, copyButton} = mount(
+            render('```text showLineNumbers\n# comment\nnpm install\n```'),
+        );
+
+        click(copyButton);
+        await flush();
+
+        // The clone is stripped, not the live DOM produced by the pipeline.
+        expect(code.querySelector('.yfm-line-number')).not.toBeNull();
+    });
+
+    it('should trigger the success animation via the visibileAnimation contract', async () => {
+        const {copyButton, animate} = mount(render('```\nnpm install\n```'));
+
+        click(copyButton);
+        await flush();
+
+        expect(
+            (must(animate, 'animate') as unknown as {beginElement: () => void}).beginElement,
+        ).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe('js/code integration — wrap button', () => {
+    it('should toggle the "wrap" class on the real code element', () => {
+        const {wrapButton: maybeWrapButton, code} = mount(
+            render('```\nline\n```', {codeLineWrapping: true}),
+        );
+        const wrapButton = must(maybeWrapButton, 'wrapButton');
+
+        click(wrapButton);
+        expect(code.classList.contains('wrap')).toBe(true);
+        expect(wrapButton.getAttribute('aria-pressed')).toBe('true');
+
+        click(wrapButton);
+        expect(code.classList.contains('wrap')).toBe(false);
+        expect(wrapButton.getAttribute('aria-pressed')).toBe('false');
+    });
+});
+
+describe('js/code integration — event guards', () => {
+    it('should ignore clicks that are not on a copy or wrap button', async () => {
+        const {code} = mount(render('```\nnpm install\n```'));
+
+        click(code);
+        await flush();
+
+        expect(mockedCopy).not.toHaveBeenCalled();
+    });
+
+    it('should ignore custom events without a matchable target', async () => {
+        mount(render('```\nnpm install\n```'));
+
+        // isCustom() returns true when the target has no matches() method.
+        document.dispatchEvent(new Event('click'));
+        await flush();
+
+        expect(mockedCopy).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request, before submitting, please read commit message formatting guidelines at https://www.conventionalcommits.org/en/v1.0.0/

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that the code is up-to-date with the `master` branch.
4. Include a description of the proposed changes and how to test them.

For Russian speaking contributors:
Перед отправкой PR-a, пожалуйста, прочтите гайды для разработчиков платформы Diplodoc : https://diplodoc.com/docs/ru/dev/
#xxxx" -->

## Description

Adds a `prompt="…"` code-fence option that renders a shell-style prompt prefix (e.g. `$`, `#`, `>>>`) on each command line. The prompt is displayed but excluded from both text selection and clipboard copy, so users copy only the runnable command.

Example:

````md
```bash prompt="$"
$ npm install
$ npm run build
```
````

Specifics:
 - Fence info option format: `prompt="<value>"` (e.g. `bash prompt="$"`), parsed alongside `showLineNumbers` and `wrap`
 - Fence-info parsing extracted into a dedicated `parseFenceInfo` helper; `showLineNumbers`/`wrap` are now matched with word boundaries instead of a naive `includes`
 - The prompt prefix is stripped from the raw fence content **before** highlighting, so language grammars never misinterpret prompt symbols (`#` as a comment, `$` as a variable)
 - Per-line prompt detection: a line matches when its trimmed content starts with `<prompt> ` or equals `<prompt>`; leading whitespace is preserved so indentation is kept
 - After highlighting, the prompt is re-inserted as a non-selectable `<span class="yfm-code-prompt" aria-hidden="true">` (with `user-select: none` / `pointer-events: none`), styled with the theme comment color
 - The raw prompt value is emitted as a `data-prompt` attribute on `<code>`, letting the copy widget strip it without depending on class names or DOM structure
 - Clipboard copy logic rewritten to clone the `<code>` node, remove `.yfm-line-number` decorations, then strip the prompt prefix per line based on `data-prompt` (leading whitespace preserved)
 - `addLineNumbers` renamed/generalized to `postProcessCode`, which now handles both line numbers and prompt rendering in a single pass
 - `wrap` class handling made robust for the `<code>` tag whether or not an existing `class` attribute is present, and works in combination with the prompt attribute
 - Token content mutation is restored to its original value after rendering so it does not leak to other token consumers
 - Tests added in `test/code.test.ts`, `test/js-code.test.ts`, and `test/highlight-code.test.ts` covering rendering, prompt stripping, clipboard copy, and highlighting interactions

Related issue: #2615

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
