### PR TITLE
fix: local url DOCSTOOLS-6242

### DIFF
--- a/src/transform/utils.ts
+++ b/src/transform/utils.ts
@@ -3,7 +3,10 @@ import type Token from 'markdown-it/lib/token';
 import {formatHref, parseHref} from '@diplodoc/utils';
 
 export function isLocalUrl(url: string) {
-    return !/^(?:[a-z]+:)?\/\//i.test(url);
+    // A URL is local unless it has an external scheme: either `scheme://...`
+    // / `//host...` (protocol-relative), or an opaque scheme URI without
+    // a slash-slash part (e.g. `mailto:`, `tel:`, `custom:`).
+    return !isExternalHref(url);
 }
 
 export function findBlockTokens(tokens: Token[], id: string) {

--- a/test/links.test.ts
+++ b/test/links.test.ts
@@ -112,6 +112,40 @@ describe('Links plugin', () => {
         expect(result).toEqual('<p><a href="/link/">Absolute link</a></p>\n');
     });
 
+    test('Should not treat mailto link ending in .md as a page link', () => {
+        const result = callPlugin(
+            links,
+            tokenize(['[centru@datepersonale.md](mailto:centru@datepersonale.md)']),
+            {
+                path: mocksPath,
+                root: dirname(mocksPath),
+                log: log,
+                getPublicPath,
+            },
+        );
+
+        const inlineTokens = result.find((token) => token.type === 'inline')?.children || [];
+        const linkToken = inlineTokens.find((token) => token.type === 'link_open');
+
+        expect(linkToken?.attrGet('href')).toEqual('mailto:centru@datepersonale.md');
+        expect(linkToken?.attrGet('target')).toEqual('_blank');
+    });
+
+    test('Should not treat tel link as a page link', () => {
+        const result = callPlugin(links, tokenize(['[+123456](tel:+123456)']), {
+            path: mocksPath,
+            root: dirname(mocksPath),
+            log: log,
+            getPublicPath,
+        });
+
+        const inlineTokens = result.find((token) => token.type === 'inline')?.children || [];
+        const linkToken = inlineTokens.find((token) => token.type === 'link_open');
+
+        expect(linkToken?.attrGet('href')).toEqual('tel:+123456');
+        expect(linkToken?.attrGet('target')).toEqual('_blank');
+    });
+
     describe('transformLink', () => {
         test('Should call the "transformLink" callback for local link', () => {
             const inputPath = resolve(__dirname, './mocks/relative-link.md');


### PR DESCRIPTION
Fixed a regression that caused a false error `Unreachable link: "mailto:centru@datepersonale.md"` when building.

## Cause

Earlier in this session, `url.parse()` in [`packages/transform/src/transform/plugins/links/index.ts`](packages/transform/src/transform/plugins/links/index.ts:156) was replaced with the new helper `parseHref` from `@diplodoc/utils`. The problem turned out to be not in the helper itself, but in the existing function [`isLocalUrl`](packages/transform/src/transform/utils.ts:5), which was supposed to cut off external links (`mailto:`, `tel:` etc.) before calling `parseHref`/`url.parse`.

 Its regex `/^(?:[a-z]+:)?\/\//i` catches only `scheme://...`` and `//host`, but it **doesn't catch** "opaque" URI schemes without `//`, like `mailto:foo@bar.md`. Previously, this hole was masked by a side effect of legacy `url.parse()`: for `mailto:centru@datepersonale.md`, it parsed `centru` as `auth`, `datepersonale.md` as `host`, and left `pathname` as `null`, and the code in the `else { return; }` branch silently skipped such a link. The new `parseHref` (as well as the correct WHATWG approach) does not use auth/host heuristics for schemes without `//` and returns the entire string after `mailto:` as `pathname`. Since the string ends with `.md`, it passed the `PAGE_LINK_REGEXP`, and the code attempted to resolve it as a document file, resulting in an `Unreachable link`.

## Fix

In [`packages/transform/src/transform/utils.ts`](packages/transform/src/transform/utils.ts:5), `isLocalUrl` reuses the existing `isExternalHref` in the same file (the same logic as in the `isExternalHref`/`isLocalUrl` of the `cli` package, which correctly catches `mailto:`, `tel:`, and custom schemes regardless of the presence of `//`):

```ts
export function isLocalUrl(url: string) {
    return !isExternalHref(url);
}
```

Now such links are cut off at the earliest stage — before the call to `parseHref` — and marked as external (`target="_blank"`, `rel="noreferrer noopener"`), as it was previously intended for external protocols.

## Checking

- Added 2 regression tests in [`packages/transform/test/links.test.ts`](packages/transform/test/links.test.ts:115): for `mailto:...md` and `tel:...` — both confirm that the link remains external and does not attempt to resolve as a file.
- `npx tsc --noEmit` in `packages/transform` — clean.
- Full set of tests for the `transform` package: **971 passed | 1 skipped** (was 969, +2 new).