### PR TITLE
fix: remove `baseUrl`, use relative imports

### DIFF
--- a/src/js/anchor.ts
+++ b/src/js/anchor.ts
@@ -1,4 +1,4 @@
-import type {Lang} from 'src/transform/typings';
+import type {Lang} from '../transform/typings';
 
 import {createTooltipFactory} from './tooltip';
 import {copyToClipboard, getEventTarget, isCustom} from './utils';

--- a/src/js/constant.ts
+++ b/src/js/constant.ts
@@ -1,4 +1,4 @@
-import type {Lang} from 'src/transform/typings';
+import type {Lang} from '../transform/typings';
 
 export const COPIED_LANG_TOKEN: Record<Lang, string> = {
     ru: 'Скопировано',

--- a/src/js/inline-code/index.ts
+++ b/src/js/inline-code/index.ts
@@ -1,4 +1,4 @@
-import type {Lang} from 'src/transform/typings';
+import type {Lang} from '../../transform/typings';
 
 import {createTooltipFactory} from '../tooltip';
 import {copyToClipboard, getEventTarget, isCustom} from '../utils';

--- a/src/transform/plugins/links/index.ts
+++ b/src/transform/plugins/links/index.ts
@@ -1,5 +1,5 @@
 import type Token from 'markdown-it/lib/token';
-import type {Logger} from 'src/transform/log';
+import type {Logger} from '../../log';
 import type {CacheContext, StateCore} from '../../typings';
 import type {MarkdownItPluginCb, MarkdownItPluginOpts} from '../typings';
 import type {MarkdownItIncluded} from '../includes/types';

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-implicit-globals */
 import type StateCore from 'markdown-it/lib/rules_core/state_core';
-import type {MarkdownItPluginCb, MarkdownItPluginOpts} from 'src/transform/plugins/typings';
+import type {MarkdownItPluginCb, MarkdownItPluginOpts} from '../src/transform/plugins/typings';
 
 import Token from 'markdown-it/lib/token';
 import MarkdownIt from 'markdown-it';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "lib": ["DOM", "ES2018"],
     "outDir": "lib",
     "module": "commonjs",
-    "baseUrl": ".",
     "declaration": true,
     "target": "ES2018",
     "types": ["node", "vitest/globals"]

--- a/tsconfig.transform.json
+++ b/tsconfig.transform.json
@@ -4,7 +4,6 @@
     "lib": ["DOM", "ES2018"],
     "outDir": "lib",
     "module": "commonjs",
-    "baseUrl": ".",
     "declaration": true,
     "isolatedModules": true,
     "noImplicitAny": true,


### PR DESCRIPTION
`baseUrl` lets TS resolve non-relative imports relative to it, but tsc does not rewrite these paths in emitted `.d.ts` files, breaking type resolution for consumers.

<!--
Thank you for submitting a Pull Request, before submitting, please read commit message formatting guidelines at https://www.conventionalcommits.org/en/v1.0.0/

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that the code is up-to-date with the `master` branch.
4. Include a description of the proposed changes and how to test them.

For Russian speaking contributors:
Перед отправкой PR-a, пожалуйста, прочтите гайды для разработчиков платформы Diplodoc : https://diplodoc.com/docs/ru/dev/
#xxxx" -->

## Description

<!-- Please include a summary of the changes. If it is feasible, it is worth attaching a screenshot or video of the changes. -->

Related issue: #(issue number)

<!-- If this is a bug fix, make sure your description includes "fixes #xxxx", or "closes #xxxx" -->
