### PR TITLE
fix: add gallery-src attr to open img in gallery

### DIFF
--- a/src/transform/plugins/images/index.ts
+++ b/src/transform/plugins/images/index.ts
@@ -115,19 +115,76 @@ function isGalleryValid(value: string): boolean {
     return value === 'true' || value === 'false';
 }
 
-function collectDataAttrs(image: Token): Record<string, string> {
+function resolveGallerySrcAttr(
+    key: string,
+    value: string,
+    state: StateCore,
+    from: string,
+    calcPath: (root: string, path: string) => string,
+    replaceImage: typeof replaceImageSrc,
+    opts: ImageOpts,
+): [string, string] | null {
+    if (key !== 'gallery-src' && key !== 'data-gallery-src') {
+        return null;
+    }
+
+    if (!value) {
+        return null;
+    }
+
+    const galleryFile = calcPath(from, value);
+    const processedSrc = replaceImage(state, from, galleryFile, value, opts);
+
+    return ['data-gallery-src', processedSrc];
+}
+
+function collectDataAttrs(
+    image: Token,
+    state: StateCore,
+    from: string,
+    calcPath: (root: string, path: string) => string,
+    replaceImage: typeof replaceImageSrc,
+    opts: ImageOpts,
+): Record<string, string> {
     const result: Record<string, string> = {};
     if (!image.attrs) return result;
 
     for (const [key, value] of image.attrs) {
         if (key === 'gallery' && isGalleryValid(value)) {
             result['data-gallery'] = value;
-        } else if (key.startsWith('data-') && (key !== 'data-gallery' || isGalleryValid(value))) {
+            continue;
+        }
+
+        const gallerySrc = resolveGallerySrcAttr(
+            key,
+            value,
+            state,
+            from,
+            calcPath,
+            replaceImage,
+            opts,
+        );
+
+        if (gallerySrc) {
+            result[gallerySrc[0]] = gallerySrc[1];
+            continue;
+        }
+
+        if (
+            key.startsWith('data-') &&
+            key !== 'data-gallery-src' &&
+            (key !== 'data-gallery' || isGalleryValid(value))
+        ) {
             result[key] = value;
         }
     }
+
     image.attrs = image.attrs.filter(
-        ([key, value]) => key !== 'gallery' && (key !== 'data-gallery' || isGalleryValid(value)),
+        ([key, value]) =>
+            key !== 'gallery' &&
+            key !== 'gallery-src' &&
+            (key !== 'data-gallery' || isGalleryValid(value)) &&
+            (key !== 'data-gallery-src' || value !== ''),
     );
     return result;
 }
@@ -162,7 +219,8 @@ const index: MarkdownItPluginCb<Opts> = (md, opts) => {
         const imgSrc = getSrcTokenAttr(image);
         if (isExternalHref(imgSrc)) return;
 
-        const dataAttrs = collectDataAttrs(image);
+        const from = state.env.path || opts.path;
+        const dataAttrs = collectDataAttrs(image, state, from, calcPath, replaceImage, opts);
         const forceInlineSvg = image.attrGet('inline') === 'true';
         const imageOpts = {
             width: image.attrGet('width'),
@@ -171,7 +229,6 @@ const index: MarkdownItPluginCb<Opts> = (md, opts) => {
             dataAttrs,
         };
 
-        const from = state.env.path || opts.path;
         const file = calcPath(from, imgSrc);
 
         if (shouldBeInlined(image, opts.svgInline)) {
@@ -225,6 +282,18 @@ const index: MarkdownItPluginCb<Opts> = (md, opts) => {
     };
 };
 
+function applyDataAttrs(svgRoot: string, dataAttrs: Record<string, string>): string {
+    let result = svgRoot;
+
+    for (const [key, value] of Object.entries(dataAttrs)) {
+        if (!result.includes(`${key}=`)) {
+            result = `${result} ${key}="${sanitizeHTMLAttr(value)}"`;
+        }
+    }
+
+    return result;
+}
+
 function replaceSvgContent(
     content: string | null,
     options: ImageOptions,
@@ -263,9 +332,7 @@ function replaceSvgContent(
     }
 
     if (options.dataAttrs) {
-        for (const [key, value] of Object.entries(options.dataAttrs)) {
-            svgRoot = `${svgRoot} ${key}="${sanitizeHTMLAttr(value)}"`;
-        }
+        svgRoot = applyDataAttrs(svgRoot, options.dataAttrs);
         content = content.replace(/<svg([^>]*)>/, `<svg${svgRoot}>`);
     }
 

--- a/src/transform/plugins/imsize/plugin.ts
+++ b/src/transform/plugins/imsize/plugin.ts
@@ -294,8 +294,10 @@ type ParsedAttrs = {
 
 function resolveDataAttr(key: string, value: string): [string, string] | null {
     const isGalleryValid = value === 'true' || value === 'false';
+
     if (key === 'gallery') return isGalleryValid ? ['data-gallery', value] : null;
     if (key === 'data-gallery') return isGalleryValid ? [key, value] : null;
+    if (key === 'gallery-src') return value !== '' ? ['data-gallery-src', value] : null;
     if (key.startsWith('data-')) return [key, value];
     return null;
 }

--- a/test/gallery.test.ts
+++ b/test/gallery.test.ts
@@ -69,4 +69,74 @@ describe('Images plugin gallery', () => {
         const html = transformYfm('![test](./test.png)');
         expect(html).not.toContain('data-gallery="true"');
     });
+
+    describe('gallery-src', () => {
+        test('should convert gallery-src attribute into data-gallery-src', () => {
+            const html = transformYfm('![test](./test.png){gallery-src=./gallery-item.png}');
+            expect(html).toMatch(/data-gallery-src="[^"]*gallery-item\.png"/);
+        });
+
+        test('should resolve gallery-src as asset path, not leave raw markdown value untouched', () => {
+            const html = transformYfm(
+                '![test](./test.png){gallery-src=./gallery-item-resolved.png}',
+            );
+
+            expect(html).toMatch(/data-gallery-src="[^"]*gallery-item-resolved\.png"/);
+        });
+
+        test('should not fail and should keep attribute when gallery-src points to a non-existent file', () => {
+            expect(() =>
+                transformYfm('![test](./test.png){gallery-src=./missing-gallery-item.png}'),
+            ).not.toThrow();
+
+            const html = transformYfm(
+                '![test](./test.png){gallery-src=./missing-gallery-item.png}',
+            );
+            expect(html).toMatch(/data-gallery-src="[^"]*missing-gallery-item\.png"/);
+        });
+
+        test('should not add data-gallery-src attribute when gallery-src value is empty', () => {
+            const html = transformYfm('![test](./test.png){gallery-src=}');
+            expect(html).not.toContain('data-gallery-src');
+        });
+
+        test('should support gallery-src together with gallery=true', () => {
+            const html = transformYfm(
+                '![test](./test.png){gallery=true gallery-src=./gallery-item2.png}',
+            );
+
+            expect(html).toContain('data-gallery="true"');
+            expect(html).toMatch(/data-gallery-src="[^"]*gallery-item2\.png"/);
+        });
+
+        test('should support gallery-src together with data-gallery=false', () => {
+            const html = transformYfm(
+                '![test](./test.png){data-gallery=false gallery-src=./gallery-item3.png}',
+            );
+
+            expect(html).toContain('data-gallery="false"');
+            expect(html).toMatch(/data-gallery-src="[^"]*gallery-item3\.png"/);
+        });
+
+        test('should handle gallery-src for inline SVG images', () => {
+            const svgPath = resolve(dirname(mocksPath), 'test-gallery.svg');
+            const svgContent =
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40" fill="red" /></svg>';
+
+            writeFileSync(svgPath, svgContent);
+
+            const html = transformYfm(
+                '![test](./test-gallery.svg){inline=true gallery-src=./gallery-item4.png}',
+            );
+
+            expect(html).toMatch(/data-gallery-src="[^"]*gallery-item4\.png"/);
+
+            unlinkSync(svgPath);
+        });
+
+        test('should not add gallery-src attribute when not set in md attribute', () => {
+            const html = transformYfm('![test](./test.png)');
+            expect(html).not.toContain('data-gallery-src');
+        });
+    });
 });


### PR DESCRIPTION
## Description

Added support for a new gallery-src markdown attribute, mapping it to data-gallery-src on the rendered <img>. 
The value is resolved as an asset path (same mechanism as the main image src), works alongside gallery/data-gallery and inline SVG images, and empty values are now properly rejected instead of producing incorrect/empty attributes. 

Added corresponding tests covering path resolution, empty values, missing files, and combinations with existing gallery attributes.
